### PR TITLE
drivers: firmware: TISCI driver support

### DIFF
--- a/drivers/firmware/CMakeLists.txt
+++ b/drivers/firmware/CMakeLists.txt
@@ -3,4 +3,5 @@
 # zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_ARM_SCMI scmi)
 add_subdirectory_ifdef(CONFIG_NRF_IRONSIDE nrf_ironside)
+add_subdirectory_ifdef(CONFIG_TISCI ti_sci)
 # zephyr-keep-sorted-stop

--- a/drivers/firmware/Kconfig
+++ b/drivers/firmware/Kconfig
@@ -13,6 +13,7 @@ config ARM_SCMI
 # zephyr-keep-sorted-start
 source "drivers/firmware/nrf_ironside/Kconfig"
 source "drivers/firmware/scmi/Kconfig"
+source "drivers/firmware/ti_sci/Kconfig"
 # zephyr-keep-sorted-stop
 
 endmenu

--- a/drivers/firmware/ti_sci/CMakeLists.txt
+++ b/drivers/firmware/ti_sci/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2025, Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources_ifdef(CONFIG_TISCI ti_sci.c)

--- a/drivers/firmware/ti_sci/Kconfig
+++ b/drivers/firmware/ti_sci/Kconfig
@@ -1,0 +1,26 @@
+# Copyright (c) 2025, Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+config TISCI
+	bool "TISCI Firmware driver"
+	depends on MBOX_TI_SECURE_PROXY
+	help
+	  TISCI firmware driver is a frontend interface
+	  to TI System Controller interface firmware through
+	  secureproxy mailbox.
+
+if TISCI
+
+config TISCI_INIT_PRIORITY
+	int "TISCI init priority"
+	default KERNEL_INIT_PRIORITY_OBJECTS
+	help
+	  Init priority for the TISCI driver.
+
+config TISCI_RESPONSE_TIMEOUT_MS
+	int "TISCI response timeout in milliseconds"
+	default 100
+	help
+	  Timeout in milliseconds to wait for a response from the TISCI firmware.
+
+endif

--- a/drivers/firmware/ti_sci/ti_sci.c
+++ b/drivers/firmware/ti_sci/ti_sci.c
@@ -1,0 +1,1547 @@
+/*
+ * Copyright (c) 2025, Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#define DT_DRV_COMPAT ti_k2g_sci
+
+#include <zephyr/drivers/mbox.h>
+#include <zephyr/device.h>
+#include "ti_sci.h"
+#include <zephyr/drivers/firmware/tisci/tisci_protocol.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+#define LOG_LEVEL CONFIG_MBOX_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(ti_k2g_sci);
+
+/**
+ * @struct tisci_config - TISCI device configuration
+ * @param mbox_tx: Mailbox transmit channel
+ * @param mbox_rx: Mailbox receive channel
+ * @param host_id: Host ID for the device
+ */
+struct tisci_config {
+	struct mbox_dt_spec mbox_tx;
+	struct mbox_dt_spec mbox_rx;
+	uint32_t host_id;
+};
+
+/**
+ * @struct rx_msg - Received message details
+ * @param seq: Message sequence number
+ * @param size: Message size in bytes
+ * @param buf: Buffer for message data
+ */
+struct rx_msg {
+	uint8_t seq;
+	uint8_t size;
+	char buf[256];
+};
+
+static struct k_mutex rx_buf_mutex;
+static struct k_sem response_ready_sem;
+
+/* Received message container */
+static struct rx_msg rx_message;
+
+/**
+ * @struct ti_sci_xfer - TISCI transfer details
+ * @param tx_message: Transmit message
+ * @param rx_message: Received message
+ * @param rx_len: Expected receive message length
+ */
+struct ti_sci_xfer {
+	struct mbox_msg tx_message;
+	struct rx_msg rx_message;
+	uint8_t rx_len;
+};
+
+/**
+ * @struct tisci_data - Runtime data for TISCI device
+ * @param xfer: Current transfer details
+ * @param desc: Device descriptor
+ * @param version: Firmware version info
+ * @param host_id: Host ID for the device
+ * @param seq: Current transfer sequence number
+ */
+struct tisci_data {
+	struct ti_sci_xfer xfer;
+	struct ti_sci_desc desc;
+	struct ti_sci_version_info version;
+	uint32_t host_id;
+	uint8_t seq;
+};
+
+/* Core/Setup Functions */
+static struct ti_sci_xfer *ti_sci_setup_one_xfer(const struct device *dev, uint16_t msg_type,
+						 uint32_t msg_flags, void *buf,
+						 size_t tx_message_size, size_t rx_message_size)
+{
+	struct tisci_data *data = dev->data;
+	struct ti_sci_xfer *xfer = &data->xfer;
+	struct ti_sci_msg_hdr *hdr;
+
+	if (rx_message_size > data->desc.max_msg_size ||
+	    tx_message_size > data->desc.max_msg_size ||
+	    (rx_message_size > 0 && rx_message_size < sizeof(*hdr)) ||
+	    tx_message_size < sizeof(*hdr)) {
+		return NULL;
+	}
+
+	data->seq++;
+	xfer->tx_message.data = buf;
+	xfer->tx_message.size = tx_message_size;
+	xfer->rx_len = (uint8_t)rx_message_size;
+
+	hdr = (struct ti_sci_msg_hdr *)buf;
+	hdr->seq = data->seq;
+	hdr->type = msg_type;
+	hdr->host = data->host_id;
+	hdr->flags = msg_flags;
+
+	return xfer;
+}
+
+static void callback(const struct device *dev, mbox_channel_id_t channel_id, void *user_data,
+		     struct mbox_msg *data)
+{
+	const struct ti_sci_msg_hdr *hdr = data->data;
+
+	if (data->size > 64) {
+		LOG_ERR("Too large incoming message");
+	}
+
+	k_mutex_lock(&rx_buf_mutex, K_FOREVER);
+	memcpy(rx_message.buf, data->data, 256);
+	rx_message.size = data->size;
+	rx_message.seq = hdr->seq;
+
+	k_sem_give(&response_ready_sem);
+}
+
+static bool ti_sci_is_response_ack(void *r)
+{
+	struct ti_sci_msg_hdr *hdr = (struct ti_sci_msg_hdr *)r;
+
+	return hdr->flags & TI_SCI_FLAG_RESP_GENERIC_ACK ? true : false;
+}
+
+static int ti_sci_get_response(const struct device *dev, struct ti_sci_xfer *xfer)
+{
+	struct tisci_data *dev_data = dev->data;
+	struct ti_sci_msg_hdr *hdr;
+	int ret = 0;
+
+	if (k_sem_take(&response_ready_sem, K_MSEC(CONFIG_TISCI_RESPONSE_TIMEOUT_MS)) != 0) {
+		LOG_ERR("Timeout waiting for response");
+		return -ETIMEDOUT;
+	}
+
+	hdr = (struct ti_sci_msg_hdr *)rx_message.buf;
+
+	/* Sanity check for message response */
+	if (hdr->seq != dev_data->seq) {
+		LOG_ERR("HDR seq != data seq [%d != %d]\n", hdr->seq, dev_data->seq);
+		return -EINVAL;
+	}
+
+	if (rx_message.size > dev_data->desc.max_msg_size) {
+		LOG_ERR("rx_message.size [ %d ] > max_msg_size\n", xfer->rx_message.size);
+		return -EINVAL;
+	}
+
+	if (rx_message.size < xfer->rx_len) {
+		LOG_ERR("rx_message.size [ %d ] < xfer->rx_len\n", xfer->rx_message.size);
+		return -EINVAL;
+	}
+
+	memcpy(xfer->rx_message.buf, rx_message.buf, sizeof(rx_message.buf));
+	k_mutex_unlock(&rx_buf_mutex);
+
+	return ret;
+}
+
+static int ti_sci_do_xfer(const struct device *dev, struct ti_sci_xfer *xfer)
+{
+	const struct tisci_config *config = dev->config;
+	struct mbox_msg *msg = &xfer->tx_message;
+	int ret;
+
+	ret = mbox_send_dt(&config->mbox_tx, msg);
+	if (ret < 0) {
+		LOG_ERR("Could not send (%d)\n", ret);
+		return 0;
+	}
+
+	/* Get response if requested */
+	if (xfer->rx_len) {
+		ret = ti_sci_get_response(dev, xfer);
+		if (!ti_sci_is_response_ack(rx_message.buf)) {
+			LOG_ERR("TISCI Response in NACK\n");
+			ret = -ENODEV;
+		}
+	}
+
+	return 0;
+}
+
+static int tisci_init(const struct device *dev)
+{
+	const struct tisci_config *config = dev->config;
+	struct tisci_data *data = dev->data;
+	int ret;
+
+	k_sem_init(&response_ready_sem, 0, 1);
+	k_mutex_init(&rx_buf_mutex);
+
+	data->host_id = config->host_id;
+	data->seq = 0x0;
+	data->desc.max_msg_size = 60;
+
+	ret = mbox_register_callback_dt(&config->mbox_rx, callback, NULL);
+	if (ret < 0) {
+		printk("Could not register callback (%d)\n", ret);
+		return 0;
+	}
+
+	ret = mbox_set_enabled_dt(&config->mbox_rx, true);
+	if (ret < 0) {
+		printk("Could not enable RX channel (%d)\n", ret);
+		return 0;
+	}
+	return 0;
+}
+
+/* Clock Management Functions */
+int ti_sci_cmd_get_clock_state(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			       uint8_t *programmed_state, uint8_t *current_state)
+{
+	struct ti_sci_msg_resp_get_clock_state *resp;
+	struct ti_sci_msg_req_get_clock_state req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_GET_CLOCK_STATE,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+
+	req.dev_id = dev_id;
+	req.clk_id = clk_id;
+	ret = ti_sci_do_xfer(dev, xfer);
+	resp = (struct ti_sci_msg_resp_get_clock_state *)xfer->rx_message.buf;
+
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	if (programmed_state) {
+		*programmed_state = resp->programmed_state;
+	}
+	if (current_state) {
+		*current_state = resp->current_state;
+	}
+	return ret;
+}
+
+int ti_sci_cmd_clk_is_auto(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			   bool *req_state)
+{
+	uint8_t state = 0;
+	int ret;
+
+	if (!req_state) {
+		return -EINVAL;
+	}
+
+	ret = ti_sci_cmd_get_clock_state(dev, dev_id, clk_id, &state, NULL);
+	if (ret) {
+		return ret;
+	}
+
+	*req_state = (state == MSG_CLOCK_SW_STATE_AUTO);
+	return 0;
+}
+
+int ti_sci_cmd_clk_is_on(const struct device *dev, uint32_t dev_id, uint8_t clk_id, bool *req_state,
+			 bool *curr_state)
+{
+	uint8_t c_state = 0, r_state = 0;
+	int ret;
+
+	if (!req_state && !curr_state) {
+		return -EINVAL;
+	}
+
+	ret = ti_sci_cmd_get_clock_state(dev, dev_id, clk_id, &r_state, &c_state);
+	if (ret) {
+		return ret;
+	}
+
+	if (req_state) {
+		*req_state = (r_state == MSG_CLOCK_SW_STATE_REQ);
+	}
+	if (curr_state) {
+		*curr_state = (c_state == MSG_CLOCK_HW_STATE_READY);
+	}
+	return 0;
+}
+
+int ti_sci_cmd_clk_is_off(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			  bool *req_state, bool *curr_state)
+{
+	uint8_t c_state = 0, r_state = 0;
+	int ret;
+
+	if (!req_state && !curr_state) {
+		return -EINVAL;
+	}
+
+	ret = ti_sci_cmd_get_clock_state(dev, dev_id, clk_id, &r_state, &c_state);
+	if (ret) {
+		return ret;
+	}
+
+	if (req_state) {
+		*req_state = (r_state == MSG_CLOCK_SW_STATE_UNREQ);
+	}
+	if (curr_state) {
+		*curr_state = (c_state == MSG_CLOCK_HW_STATE_NOT_READY);
+	}
+	return 0;
+}
+
+int ti_sci_cmd_clk_get_match_freq(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+				  uint64_t min_freq, uint64_t target_freq, uint64_t max_freq,
+				  uint64_t *match_freq)
+{
+	struct ti_sci_msg_resp_query_clock_freq *resp;
+	struct ti_sci_msg_req_query_clock_freq req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_QUERY_CLOCK_FREQ,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+
+	req.dev_id = dev_id;
+	req.clk_id = clk_id;
+	req.min_freq_hz = min_freq;
+	req.target_freq_hz = target_freq;
+	req.max_freq_hz = max_freq;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		return ret;
+	}
+
+	resp = (struct ti_sci_msg_resp_query_clock_freq *)xfer->rx_message.buf;
+
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	*match_freq = resp->freq_hz;
+
+	return 0;
+}
+
+int ti_sci_cmd_clk_set_freq(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			    uint64_t min_freq, uint64_t target_freq, uint64_t max_freq)
+{
+	struct ti_sci_msg_req_set_clock_freq req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_SET_CLOCK_FREQ,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	req.dev_id = dev_id;
+	req.clk_id = clk_id;
+	req.min_freq_hz = min_freq;
+	req.target_freq_hz = target_freq;
+	req.max_freq_hz = max_freq;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+
+	return ret;
+}
+
+int ti_sci_cmd_clk_get_freq(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			    uint64_t *freq)
+{
+	struct ti_sci_msg_resp_get_clock_freq *resp;
+	struct ti_sci_msg_req_get_clock_freq req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_GET_CLOCK_FREQ,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	req.dev_id = dev_id;
+	req.clk_id = clk_id;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		return ret;
+	}
+
+	resp = (struct ti_sci_msg_resp_get_clock_freq *)xfer->rx_message.buf;
+
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	*freq = resp->freq_hz;
+
+	return 0;
+}
+
+int ti_sci_set_clock_state(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			   uint32_t flags, uint8_t state)
+{
+	struct ti_sci_msg_req_set_clock_state req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_SET_CLOCK_STATE,
+				     flags | TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup transfer");
+		return -EINVAL;
+	}
+
+	req.dev_id = dev_id;
+	req.clk_id = clk_id;
+	req.request_state = state;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to set clock state (ret=%d)", ret);
+	}
+
+	return 0;
+}
+
+int ti_sci_cmd_clk_set_parent(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			      uint8_t parent_id)
+{
+	struct ti_sci_msg_req_set_clock_parent req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_SET_CLOCK_PARENT,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+
+	req.dev_id = dev_id;
+	req.clk_id = clk_id;
+	req.parent_id = parent_id;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to set clock parent (ret=%d)", ret);
+	}
+
+	return 0;
+}
+
+int ti_sci_cmd_clk_get_parent(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			      uint8_t *parent_id)
+{
+	struct ti_sci_msg_resp_get_clock_parent *resp;
+	struct ti_sci_msg_req_get_clock_parent req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_GET_CLOCK_PARENT,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup transfer");
+		return -EINVAL;
+	}
+
+	req.dev_id = dev_id;
+	req.clk_id = clk_id;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to get clock parent (ret=%d)", ret);
+		return ret;
+	}
+
+	resp = (struct ti_sci_msg_resp_get_clock_parent *)xfer->rx_message.buf;
+
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	*parent_id = resp->parent_id;
+
+	return 0;
+}
+
+int ti_sci_cmd_clk_get_num_parents(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+				   uint8_t *num_parents)
+{
+	struct ti_sci_msg_resp_get_clock_num_parents *resp;
+	struct ti_sci_msg_req_get_clock_num_parents req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_GET_NUM_CLOCK_PARENTS,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+
+	req.dev_id = dev_id;
+	req.clk_id = clk_id;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to get number of clock parents (ret=%d)", ret);
+		return ret;
+	}
+
+	resp = (struct ti_sci_msg_resp_get_clock_num_parents *)xfer->rx_message.buf;
+
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	*num_parents = resp->num_parents;
+
+	return 0;
+}
+
+int ti_sci_cmd_get_clock(const struct device *dev, uint32_t dev_id, uint8_t clk_id, bool needs_ssc,
+			 bool can_change_freq, bool enable_input_term)
+{
+	uint32_t flags = 0;
+
+	flags |= needs_ssc ? MSG_FLAG_CLOCK_ALLOW_SSC : 0;
+	flags |= can_change_freq ? MSG_FLAG_CLOCK_ALLOW_FREQ_CHANGE : 0;
+	flags |= enable_input_term ? MSG_FLAG_CLOCK_INPUT_TERM : 0;
+
+	return ti_sci_set_clock_state(dev, dev_id, clk_id, flags, MSG_CLOCK_SW_STATE_REQ);
+}
+
+int ti_sci_cmd_idle_clock(const struct device *dev, uint32_t dev_id, uint8_t clk_id)
+{
+	return ti_sci_set_clock_state(dev, dev_id, clk_id, 0, MSG_CLOCK_SW_STATE_UNREQ);
+}
+
+int ti_sci_cmd_put_clock(const struct device *dev, uint32_t dev_id, uint8_t clk_id)
+{
+	return ti_sci_set_clock_state(dev, dev_id, clk_id, 0, MSG_CLOCK_SW_STATE_UNREQ);
+}
+
+/* Device Management Functions */
+int ti_sci_set_device_state(const struct device *dev, uint32_t dev_id, uint32_t flags,
+			    uint8_t state)
+{
+	struct ti_sci_msg_req_set_device_state req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_SET_DEVICE_STATE,
+				     flags | TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+
+	req.id = dev_id;
+	req.state = state;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+
+	return ret;
+}
+
+int ti_sci_set_device_state_no_wait(const struct device *dev, uint32_t dev_id, uint32_t flags,
+				    uint8_t state)
+{
+	struct ti_sci_msg_req_set_device_state req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_SET_DEVICE_STATE,
+				     flags | TI_SCI_FLAG_REQ_GENERIC_NORESPONSE, (uint32_t *)&req,
+				     sizeof(req), 0);
+
+	req.id = dev_id;
+	req.state = state;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to set device state without wait (ret=%d)", ret);
+	}
+
+	return 0;
+}
+
+int ti_sci_get_device_state(const struct device *dev, uint32_t dev_id, uint32_t *clcnt,
+			    uint32_t *resets, uint8_t *p_state, uint8_t *c_state)
+{
+	struct ti_sci_msg_resp_get_device_state *resp;
+	struct ti_sci_msg_req_get_device_state req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	if (!clcnt && !resets && !p_state && !c_state) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_GET_DEVICE_STATE,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+
+	req.id = dev_id;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to get device state (ret=%d)", ret);
+		return ret;
+	}
+
+	resp = (struct ti_sci_msg_resp_get_device_state *)xfer->rx_message.buf;
+
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	if (clcnt) {
+		*clcnt = resp->context_loss_count;
+	}
+	if (resets) {
+		*resets = resp->resets;
+	}
+	if (p_state) {
+		*p_state = resp->programmed_state;
+	}
+	if (c_state) {
+		*c_state = resp->current_state;
+	}
+
+	return 0;
+}
+
+int ti_sci_cmd_get_device(const struct device *dev, uint32_t dev_id)
+{
+	return ti_sci_set_device_state(dev, dev_id, 0, MSG_DEVICE_SW_STATE_ON);
+}
+
+int ti_sci_cmd_get_device_exclusive(const struct device *dev, uint32_t dev_id)
+{
+	return ti_sci_set_device_state(dev, dev_id, MSG_FLAG_DEVICE_EXCLUSIVE,
+				       MSG_DEVICE_SW_STATE_ON);
+}
+
+int ti_sci_cmd_idle_device(const struct device *dev, uint32_t dev_id)
+{
+	return ti_sci_set_device_state(dev, dev_id, 0, MSG_DEVICE_SW_STATE_RETENTION);
+}
+
+int ti_sci_cmd_idle_device_exclusive(const struct device *dev, uint32_t dev_id)
+{
+	return ti_sci_set_device_state(dev, dev_id, MSG_FLAG_DEVICE_EXCLUSIVE,
+				       MSG_DEVICE_SW_STATE_RETENTION);
+}
+
+int ti_sci_cmd_put_device(const struct device *dev, uint32_t dev_id)
+{
+	return ti_sci_set_device_state(dev, dev_id, 0, MSG_DEVICE_SW_STATE_AUTO_OFF);
+}
+
+int ti_sci_cmd_dev_is_valid(const struct device *dev, uint32_t dev_id)
+{
+	uint8_t unused;
+
+	return ti_sci_get_device_state(dev, dev_id, NULL, NULL, NULL, &unused);
+}
+
+int ti_sci_cmd_dev_get_clcnt(const struct device *dev, uint32_t dev_id, uint32_t *count)
+{
+	return ti_sci_get_device_state(dev, dev_id, count, NULL, NULL, NULL);
+}
+
+int ti_sci_cmd_dev_is_idle(const struct device *dev, uint32_t dev_id, bool *r_state)
+{
+	int ret;
+	uint8_t state;
+
+	if (!r_state) {
+		return -EINVAL;
+	}
+
+	ret = ti_sci_get_device_state(dev, dev_id, NULL, NULL, &state, NULL);
+	if (ret) {
+		return ret;
+	}
+
+	*r_state = (state == MSG_DEVICE_SW_STATE_RETENTION);
+
+	return 0;
+}
+
+int ti_sci_cmd_dev_is_stop(const struct device *dev, uint32_t dev_id, bool *r_state,
+			   bool *curr_state)
+{
+	int ret;
+	uint8_t p_state, c_state;
+
+	if (!r_state && !curr_state) {
+		return -EINVAL;
+	}
+
+	ret = ti_sci_get_device_state(dev, dev_id, NULL, NULL, &p_state, &c_state);
+	if (ret) {
+		return ret;
+	}
+
+	if (r_state) {
+		*r_state = (p_state == MSG_DEVICE_SW_STATE_AUTO_OFF);
+	}
+	if (curr_state) {
+		*curr_state = (c_state == MSG_DEVICE_HW_STATE_OFF);
+	}
+
+	return 0;
+}
+
+int ti_sci_cmd_dev_is_on(const struct device *dev, uint32_t dev_id, bool *r_state, bool *curr_state)
+{
+	int ret;
+	uint8_t p_state, c_state;
+
+	if (!r_state && !curr_state) {
+		return -EINVAL;
+	}
+
+	ret = ti_sci_get_device_state(dev, dev_id, NULL, NULL, &p_state, &c_state);
+	if (ret) {
+		return ret;
+	}
+
+	if (r_state) {
+		*r_state = (p_state == MSG_DEVICE_SW_STATE_ON);
+	}
+	if (curr_state) {
+		*curr_state = (c_state == MSG_DEVICE_HW_STATE_ON);
+	}
+
+	return 0;
+}
+
+int ti_sci_cmd_dev_is_trans(const struct device *dev, uint32_t dev_id, bool *curr_state)
+{
+	int ret;
+	uint8_t state;
+
+	if (!curr_state) {
+		return -EINVAL;
+	}
+
+	ret = ti_sci_get_device_state(dev, dev_id, NULL, NULL, NULL, &state);
+	if (ret) {
+		return ret;
+	}
+
+	*curr_state = (state == MSG_DEVICE_HW_STATE_TRANS);
+
+	return 0;
+}
+
+int ti_sci_cmd_set_device_resets(const struct device *dev, uint32_t dev_id, uint32_t reset_state)
+{
+	struct ti_sci_msg_req_set_device_resets req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_SET_DEVICE_RESETS,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup transfer");
+		return -EINVAL;
+	}
+
+	req.id = dev_id;
+	req.resets = reset_state;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to set device resets (ret=%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int ti_sci_cmd_get_device_resets(const struct device *dev, uint32_t dev_id, uint32_t *reset_state)
+{
+	return ti_sci_get_device_state(dev, dev_id, NULL, reset_state, NULL, NULL);
+}
+
+/* Processor Management Functions */
+int ti_sci_cmd_proc_request(const struct device *dev, uint8_t proc_id)
+{
+	struct ti_sci_msg_req_proc_request req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_PROC_REQUEST, TI_SCI_FLAG_REQ_ACK_ON_PROCESSED,
+				     (uint32_t *)&req, sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup transfer");
+		return -EINVAL;
+	}
+
+	req.processor_id = proc_id;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to request processor control (ret=%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int ti_sci_cmd_proc_release(const struct device *dev, uint8_t proc_id)
+{
+	struct ti_sci_msg_req_proc_release req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_PROC_RELEASE, TI_SCI_FLAG_REQ_ACK_ON_PROCESSED,
+				     (uint32_t *)&req, sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup transfer");
+		return -EINVAL;
+	}
+
+	req.processor_id = proc_id;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to release processor control (ret=%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int ti_sci_cmd_proc_handover(const struct device *dev, uint8_t proc_id, uint8_t host_id)
+{
+	struct ti_sci_msg_req_proc_handover req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_PROC_HANDOVER, TI_SCI_FLAG_REQ_ACK_ON_PROCESSED,
+				     (uint32_t *)&req, sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup transfer");
+		return -EINVAL;
+	}
+
+	req.processor_id = proc_id;
+	req.host_id = host_id;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to handover processor control (ret=%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int ti_sci_cmd_set_proc_boot_cfg(const struct device *dev, uint8_t proc_id, uint64_t bootvector,
+				 uint32_t config_flags_set, uint32_t config_flags_clear)
+{
+	struct ti_sci_msg_req_set_proc_boot_config req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_SET_PROC_BOOT_CONFIG,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup transfer");
+		return -EINVAL;
+	}
+
+	req.processor_id = proc_id;
+	req.bootvector_low = bootvector & TISCI_ADDR_LOW_MASK;
+	req.bootvector_high = (bootvector & TISCI_ADDR_HIGH_MASK) >> TISCI_ADDR_HIGH_SHIFT;
+	req.config_flags_set = config_flags_set;
+	req.config_flags_clear = config_flags_clear;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to set processor boot configuration (ret=%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int ti_sci_cmd_set_proc_boot_ctrl(const struct device *dev, uint8_t proc_id,
+				  uint32_t control_flags_set, uint32_t control_flags_clear)
+{
+	struct ti_sci_msg_req_set_proc_boot_ctrl req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_SET_PROC_BOOT_CTRL,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup transfer");
+		return -EINVAL;
+	}
+
+	req.processor_id = proc_id;
+	req.control_flags_set = control_flags_set;
+	req.control_flags_clear = control_flags_clear;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to set processor boot control (ret=%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int ti_sci_cmd_proc_auth_boot_image(const struct device *dev, uint64_t *image_addr,
+				    uint32_t *image_size)
+{
+	struct ti_sci_msg_req_proc_auth_boot_image req;
+	struct ti_sci_msg_resp_proc_auth_boot_image *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_PROC_AUTH_BOOT_IMAGE,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup transfer");
+		return -EINVAL;
+	}
+
+	req.cert_addr_low = *image_addr & TISCI_ADDR_LOW_MASK;
+	req.cert_addr_high = (*image_addr & TISCI_ADDR_HIGH_MASK) >> TISCI_ADDR_HIGH_SHIFT;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to authenticate boot image (ret=%d)", ret);
+		return ret;
+	}
+
+	resp = (struct ti_sci_msg_resp_proc_auth_boot_image *)xfer->rx_message.buf;
+
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	*image_addr =
+		(resp->image_addr_low & TISCI_ADDR_LOW_MASK) |
+		(((uint64_t)resp->image_addr_high << TISCI_ADDR_HIGH_SHIFT) & TISCI_ADDR_HIGH_MASK);
+	*image_size = resp->image_size;
+
+	return 0;
+}
+
+int ti_sci_cmd_get_proc_boot_status(const struct device *dev, uint8_t proc_id, uint64_t *bv,
+				    uint32_t *cfg_flags, uint32_t *ctrl_flags, uint32_t *sts_flags)
+{
+	struct ti_sci_msg_resp_get_proc_boot_status *resp;
+	struct ti_sci_msg_req_get_proc_boot_status req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_GET_PROC_BOOT_STATUS,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup transfer");
+		return -EINVAL;
+	}
+
+	req.processor_id = proc_id;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Failed to get processor boot status (ret=%d)", ret);
+		return ret;
+	}
+
+	resp = (struct ti_sci_msg_resp_get_proc_boot_status *)xfer->rx_message.buf;
+
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	*bv = (resp->bootvector_low & TISCI_ADDR_LOW_MASK) |
+	      (((uint64_t)resp->bootvector_high << TISCI_ADDR_HIGH_SHIFT) & TISCI_ADDR_HIGH_MASK);
+	*cfg_flags = resp->config_flags;
+	*ctrl_flags = resp->control_flags;
+	*sts_flags = resp->status_flags;
+
+	return 0;
+}
+
+/* Resource Management Functions */
+int ti_sci_get_resource_range(const struct device *dev, uint32_t dev_id, uint8_t subtype,
+			      uint8_t s_host, uint16_t *range_start, uint16_t *range_num)
+{
+	struct ti_sci_msg_resp_get_resource_range *resp;
+	struct ti_sci_msg_req_get_resource_range req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_GET_RESOURCE_RANGE,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup transfer");
+		return -EINVAL;
+	}
+
+	req.secondary_host = s_host;
+	req.type = dev_id & MSG_RM_RESOURCE_TYPE_MASK;
+	req.subtype = subtype & MSG_RM_RESOURCE_SUBTYPE_MASK;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		return ret;
+	}
+
+	resp = (struct ti_sci_msg_resp_get_resource_range *)xfer->rx_message.buf;
+
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	if (!resp->range_start && !resp->range_num) {
+		return -ENODEV;
+	}
+
+	*range_start = resp->range_start;
+	*range_num = resp->range_num;
+
+	return 0;
+}
+
+int ti_sci_cmd_get_resource_range(const struct device *dev, uint32_t dev_id, uint8_t subtype,
+				  uint16_t *range_start, uint16_t *range_num)
+{
+	return ti_sci_get_resource_range(dev, dev_id, subtype, TI_SCI_IRQ_SECONDARY_HOST_INVALID,
+					 range_start, range_num);
+}
+
+int ti_sci_cmd_get_resource_range_from_shost(const struct device *dev, uint32_t dev_id,
+					     uint8_t subtype, uint8_t s_host, uint16_t *range_start,
+					     uint16_t *range_num)
+{
+	return ti_sci_get_resource_range(dev, dev_id, subtype, s_host, range_start, range_num);
+}
+
+/* Board Configuration Functions */
+
+int cmd_set_board_config_using_msg(const struct device *dev, uint16_t msg_type, uint64_t addr,
+				   uint32_t size)
+{
+	struct ti_sci_msg_board_config req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, msg_type, TI_SCI_FLAG_REQ_ACK_ON_PROCESSED,
+				     (uint32_t *)&req, sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup board config transfer");
+		return -EINVAL;
+	}
+
+	req.boardcfgp_high = (addr >> 32) & 0xFFFFFFFFU;
+	req.boardcfgp_low = addr & 0xFFFFFFFFU;
+	req.boardcfg_size = size;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Board config transfer failed (ret=%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/* Version/Revision Function */
+int ti_sci_cmd_get_revision(const struct device *dev)
+{
+	struct tisci_data *data = dev->data;
+	struct ti_sci_msg_hdr hdr;
+	struct ti_sci_version_info *ver;
+	struct ti_sci_msg_resp_version *rev_info;
+	struct ti_sci_xfer *xfer;
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_VERSION, TI_SCI_FLAG_REQ_ACK_ON_PROCESSED,
+				     &hdr, sizeof(struct ti_sci_msg_hdr), sizeof(*rev_info));
+
+	ti_sci_do_xfer(dev, xfer);
+
+	rev_info = (struct ti_sci_msg_resp_version *)xfer->rx_message.buf;
+
+	if (!rev_info) {
+		return -ENOMEM;
+	}
+
+	ver = &data->version;
+	ver->abi_major = rev_info->abi_major;
+	ver->abi_minor = rev_info->abi_minor;
+	ver->firmware_revision = rev_info->firmware_revision;
+	printf("%s", rev_info->firmware_description);
+	strncpy(ver->firmware_description, rev_info->firmware_description,
+		sizeof(ver->firmware_description));
+	return 0;
+}
+
+/* System Control Functions */
+
+int ti_sci_cmd_sys_reset(const struct device *dev)
+{
+	struct ti_sci_msg_req_reboot req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_SYS_RESET, TI_SCI_FLAG_REQ_ACK_ON_PROCESSED,
+				     (uint32_t *)&req, sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup system reset transfer");
+		return -EINVAL;
+	}
+
+	req.domain = 0;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("System reset request failed (ret=%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/* Memory Management Functions */
+
+int ti_sci_cmd_query_msmc(const struct device *dev, uint64_t *msmc_start, uint64_t *msmc_end)
+{
+	struct ti_sci_msg_resp_query_msmc *resp;
+	struct ti_sci_msg_hdr req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev || !msmc_start || !msmc_end) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_QUERY_MSMC, TI_SCI_FLAG_REQ_ACK_ON_PROCESSED,
+				     (uint32_t *)&req, sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup MSMC query transfer");
+		return -EINVAL;
+	}
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("MSMC query failed (ret=%d)", ret);
+		return ret;
+	}
+
+	resp = (struct ti_sci_msg_resp_query_msmc *)xfer->rx_message.buf;
+
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	*msmc_start =
+		((uint64_t)resp->msmc_start_high << TISCI_ADDR_HIGH_SHIFT) | resp->msmc_start_low;
+	*msmc_end = ((uint64_t)resp->msmc_end_high << TISCI_ADDR_HIGH_SHIFT) | resp->msmc_end_low;
+
+	return 0;
+}
+
+/* Firewall Management Functions */
+
+int ti_sci_cmd_set_fwl_region(const struct device *dev, const struct ti_sci_msg_fwl_region *region)
+{
+	struct ti_sci_msg_fwl_set_firewall_region_req req;
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev || !region) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_FWL_SET, TI_SCI_FLAG_REQ_ACK_ON_PROCESSED,
+				     (uint32_t *)&req, sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup firewall config transfer");
+		return -EINVAL;
+	}
+
+	req.fwl_id = region->fwl_id;
+	req.region = region->region;
+	req.n_permission_regs = region->n_permission_regs;
+	req.control = region->control;
+	memcpy(req.permissions, region->permissions, sizeof(uint32_t) * FWL_MAX_PRIVID_SLOTS);
+	req.start_address = region->start_address;
+	req.end_address = region->end_address;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Firewall config transfer failed (ret=%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int ti_sci_cmd_get_fwl_region(const struct device *dev, struct ti_sci_msg_fwl_region *region)
+{
+	struct ti_sci_msg_fwl_get_firewall_region_req req;
+	struct ti_sci_msg_fwl_get_firewall_region_resp *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev || !region) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_FWL_GET, TI_SCI_FLAG_REQ_ACK_ON_PROCESSED,
+				     (uint32_t *)&req, sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup firewall query transfer");
+		return -EINVAL;
+	}
+
+	req.fwl_id = region->fwl_id;
+	req.region = region->region;
+	req.n_permission_regs = region->n_permission_regs;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Firewall query transfer failed (ret=%d)", ret);
+		return ret;
+	}
+
+	resp = (struct ti_sci_msg_fwl_get_firewall_region_resp *)xfer->rx_message.buf;
+
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	region->fwl_id = resp->fwl_id;
+	region->region = resp->region;
+	region->n_permission_regs = resp->n_permission_regs;
+	region->control = resp->control;
+	memcpy(region->permissions, resp->permissions, sizeof(uint32_t) * FWL_MAX_PRIVID_SLOTS);
+	region->start_address = resp->start_address;
+	region->end_address = resp->end_address;
+
+	return 0;
+}
+
+int ti_sci_cmd_change_fwl_owner(const struct device *dev, struct ti_sci_msg_fwl_owner *owner)
+{
+	struct ti_sci_msg_fwl_change_owner_info_req req;
+	struct ti_sci_msg_fwl_change_owner_info_resp *resp;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev || !owner) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_FWL_CHANGE_OWNER,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup firewall owner change transfer");
+		return -EINVAL;
+	}
+
+	req.fwl_id = owner->fwl_id;
+	req.region = owner->region;
+	req.owner_index = owner->owner_index;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("Firewall owner change failed (ret=%d)", ret);
+		return ret;
+	}
+
+	resp = (struct ti_sci_msg_fwl_change_owner_info_resp *)xfer->rx_message.buf;
+
+	if (!resp) {
+		return -ENOMEM;
+	}
+
+	owner->fwl_id = resp->fwl_id;
+	owner->region = resp->region;
+	owner->owner_index = resp->owner_index;
+	owner->owner_privid = resp->owner_privid;
+	owner->owner_permission_bits = resp->owner_permission_bits;
+
+	return 0;
+}
+
+/* UDMAP Management Functions */
+
+int ti_sci_cmd_rm_udmap_tx_ch_cfg(const struct device *dev,
+				  const struct ti_sci_msg_rm_udmap_tx_ch_cfg *params)
+{
+	struct ti_sci_msg_rm_udmap_tx_ch_cfg_resp *resp;
+	struct ti_sci_msg_rm_udmap_tx_ch_cfg req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev || !params) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_RM_UDMAP_TX_CH_CFG,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup UDMAP TX channel config transfer");
+		return -EINVAL;
+	}
+
+	/* Copy all configuration parameters */
+	req.valid_params = params->valid_params;
+	req.nav_id = params->nav_id;
+	req.index = params->index;
+	req.tx_pause_on_err = params->tx_pause_on_err;
+	req.tx_filt_einfo = params->tx_filt_einfo;
+	req.tx_filt_pswords = params->tx_filt_pswords;
+	req.tx_atype = params->tx_atype;
+	req.tx_chan_type = params->tx_chan_type;
+	req.tx_supr_tdpkt = params->tx_supr_tdpkt;
+	req.tx_fetch_size = params->tx_fetch_size;
+	req.tx_credit_count = params->tx_credit_count;
+	req.txcq_qnum = params->txcq_qnum;
+	req.tx_priority = params->tx_priority;
+	req.tx_qos = params->tx_qos;
+	req.tx_orderid = params->tx_orderid;
+	req.fdepth = params->fdepth;
+	req.tx_sched_priority = params->tx_sched_priority;
+	req.tx_burst_size = params->tx_burst_size;
+	req.tx_tdtype = params->tx_tdtype;
+	req.extended_ch_type = params->extended_ch_type;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("UDMAP TX channel %u config failed (ret=%d)", params->index, ret);
+		return ret;
+	}
+
+	LOG_DBG("UDMAP TX channel %u configured successfully", params->index);
+	return 0;
+}
+
+int ti_sci_cmd_rm_udmap_rx_ch_cfg(const struct device *dev,
+				  const struct ti_sci_msg_rm_udmap_rx_ch_cfg *params)
+{
+	struct ti_sci_msg_rm_udmap_rx_ch_cfg_resp *resp;
+	struct ti_sci_msg_rm_udmap_rx_ch_cfg_req req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev || !params) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TISCI_MSG_RM_UDMAP_RX_CH_CFG,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup UDMAP RX channel config transfer");
+		return -EINVAL;
+	}
+
+	/* Copy all configuration parameters */
+	req.valid_params = params->valid_params;
+	req.nav_id = params->nav_id;
+	req.index = params->index;
+	req.rx_fetch_size = params->rx_fetch_size;
+	req.rxcq_qnum = params->rxcq_qnum;
+	req.rx_priority = params->rx_priority;
+	req.rx_qos = params->rx_qos;
+	req.rx_orderid = params->rx_orderid;
+	req.rx_sched_priority = params->rx_sched_priority;
+	req.flowid_start = params->flowid_start;
+	req.flowid_cnt = params->flowid_cnt;
+	req.rx_pause_on_err = params->rx_pause_on_err;
+	req.rx_atype = params->rx_atype;
+	req.rx_chan_type = params->rx_chan_type;
+	req.rx_ignore_short = params->rx_ignore_short;
+	req.rx_ignore_long = params->rx_ignore_long;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("UDMAP RX channel %u config failed (ret=%d)", params->index, ret);
+		return ret;
+	}
+
+	LOG_DBG("UDMAP RX channel %u configured successfully", params->index);
+	return 0;
+}
+
+/* PSI-L Management Functions */
+
+int ti_sci_cmd_rm_psil_pair(const struct device *dev, uint32_t nav_id, uint32_t src_thread,
+			    uint32_t dst_thread)
+{
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_msg_psil_pair req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_RM_PSIL_PAIR, TI_SCI_FLAG_REQ_ACK_ON_PROCESSED,
+				     (uint32_t *)&req, sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup PSI-L pair transfer");
+		return -EINVAL;
+	}
+
+	req.nav_id = nav_id;
+	req.src_thread = src_thread;
+	req.dst_thread = dst_thread;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("PSI-L pair failed nav:%u %u->%u (ret=%d)", nav_id, src_thread, dst_thread,
+			ret);
+		return ret;
+	}
+
+	LOG_DBG("PSI-L pair successful nav:%u %u->%u", nav_id, src_thread, dst_thread);
+	return 0;
+}
+
+int ti_sci_cmd_rm_psil_unpair(const struct device *dev, uint32_t nav_id, uint32_t src_thread,
+			      uint32_t dst_thread)
+{
+	struct ti_sci_msg_hdr *resp;
+	struct ti_sci_msg_psil_unpair req;
+	struct ti_sci_xfer *xfer;
+	int ret = 0;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	xfer = ti_sci_setup_one_xfer(dev, TI_SCI_MSG_RM_PSIL_UNPAIR,
+				     TI_SCI_FLAG_REQ_ACK_ON_PROCESSED, (uint32_t *)&req,
+				     sizeof(req), sizeof(*resp));
+	if (!xfer) {
+		LOG_ERR("Failed to setup PSI-L unpair transfer");
+		return -EINVAL;
+	}
+
+	req.nav_id = nav_id;
+	req.src_thread = src_thread;
+	req.dst_thread = dst_thread;
+
+	ret = ti_sci_do_xfer(dev, xfer);
+	if (ret) {
+		LOG_ERR("PSI-L unpair failed %u->%u (ret=%d)", src_thread, dst_thread, ret);
+		return ret;
+	}
+
+	LOG_DBG("PSI-L unpair successful %u->%u", src_thread, dst_thread);
+	return 0;
+}
+/* Device Tree Instantiation */
+#define TISCI_DEFINE(_n)                                                                           \
+	static struct tisci_data tisci_data_##_n;                                                  \
+	static const struct tisci_config tisci_config_##_n = {                                     \
+		.mbox_tx = MBOX_DT_SPEC_INST_GET(_n, tx),                                          \
+		.mbox_rx = MBOX_DT_SPEC_INST_GET(_n, rx),                                          \
+		.host_id = DT_INST_PROP(_n, ti_host_id),                                           \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(_n, tisci_init, NULL, &tisci_data_##_n, &tisci_config_##_n,          \
+			      PRE_KERNEL_1, CONFIG_TISCI_INIT_PRIORITY, NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(TISCI_DEFINE)

--- a/drivers/firmware/ti_sci/ti_sci.h
+++ b/drivers/firmware/ti_sci/ti_sci.h
@@ -1,0 +1,1598 @@
+/*
+ * Copyright (c) 2025, Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Texas Instruments System Control Interface (TISCI) Protocol
+ *
+ */
+
+#ifndef INCLUDE_ZEPHYR_DRIVERS_TISCI_PROTOCOL_H_
+#define INCLUDE_ZEPHYR_DRIVERS_TISCI_PROTOCOL_H_
+
+#include <stdint.h>
+
+#define TI_SCI_MSG_ENABLE_WDT            0x0000
+#define TI_SCI_MSG_WAKE_RESET            0x0001
+#define TI_SCI_MSG_VERSION               0x0002
+#define TI_SCI_MSG_WAKE_REASON           0x0003
+#define TI_SCI_MSG_GOODBYE               0x0004
+#define TI_SCI_MSG_SYS_RESET             0x0005
+#define TI_SCI_MSG_BOARD_CONFIG          0x000b
+#define TI_SCI_MSG_BOARD_CONFIG_RM       0x000c
+#define TI_SCI_MSG_BOARD_CONFIG_SECURITY 0x000d
+#define TI_SCI_MSG_BOARD_CONFIG_PM       0x000e
+#define TISCI_MSG_QUERY_MSMC             0x0020
+
+/* Device requests */
+#define TI_SCI_MSG_SET_DEVICE_STATE  0x0200
+#define TI_SCI_MSG_GET_DEVICE_STATE  0x0201
+#define TI_SCI_MSG_SET_DEVICE_RESETS 0x0202
+
+/* Clock requests */
+#define TI_SCI_MSG_SET_CLOCK_STATE       0x0100
+#define TI_SCI_MSG_GET_CLOCK_STATE       0x0101
+#define TI_SCI_MSG_SET_CLOCK_PARENT      0x0102
+#define TI_SCI_MSG_GET_CLOCK_PARENT      0x0103
+#define TI_SCI_MSG_GET_NUM_CLOCK_PARENTS 0x0104
+#define TI_SCI_MSG_SET_CLOCK_FREQ        0x010c
+#define TI_SCI_MSG_QUERY_CLOCK_FREQ      0x010d
+#define TI_SCI_MSG_GET_CLOCK_FREQ        0x010e
+
+/* Processor Control Messages */
+#define TISCI_MSG_PROC_REQUEST          0xc000
+#define TISCI_MSG_PROC_RELEASE          0xc001
+#define TISCI_MSG_PROC_HANDOVER         0xc005
+#define TISCI_MSG_SET_PROC_BOOT_CONFIG  0xc100
+#define TISCI_MSG_SET_PROC_BOOT_CTRL    0xc101
+#define TISCI_MSG_PROC_AUTH_BOOT_IMAGE  0xc120
+#define TISCI_MSG_GET_PROC_BOOT_STATUS  0xc400
+#define TISCI_MSG_WAIT_PROC_BOOT_STATUS 0xc401
+
+/* Resource Management Requests */
+#define TI_SCI_MSG_GET_RESOURCE_RANGE 0x1500
+
+/* NAVSS resource management */
+/* Ringacc requests */
+#define TI_SCI_MSG_RM_RING_CFG 0x1110
+
+/* PSI-L requests */
+#define TI_SCI_MSG_RM_PSIL_PAIR   0x1280
+#define TI_SCI_MSG_RM_PSIL_UNPAIR 0x1281
+
+#define TI_SCI_MSG_RM_UDMAP_TX_ALLOC     0x1200
+#define TI_SCI_MSG_RM_UDMAP_TX_FREE      0x1201
+#define TI_SCI_MSG_RM_UDMAP_RX_ALLOC     0x1210
+#define TI_SCI_MSG_RM_UDMAP_RX_FREE      0x1211
+#define TI_SCI_MSG_RM_UDMAP_FLOW_CFG     0x1220
+#define TI_SCI_MSG_RM_UDMAP_OPT_FLOW_CFG 0x1221
+
+#define TISCI_MSG_RM_UDMAP_TX_CH_CFG            0x1205
+#define TISCI_MSG_RM_UDMAP_RX_CH_CFG            0x1215
+#define TISCI_MSG_RM_UDMAP_FLOW_CFG             0x1230
+#define TISCI_MSG_RM_UDMAP_FLOW_SIZE_THRESH_CFG 0x1231
+
+#define TISCI_MSG_FWL_SET          0x9000
+#define TISCI_MSG_FWL_GET          0x9001
+#define TISCI_MSG_FWL_CHANGE_OWNER 0x9002
+
+/**
+ * @struct ti_sci_msg_hdr
+ * @brief Generic Message Header for All messages and responses
+ * @param type:	Type of messages: One of TI_SCI_MSG* values
+ * @param host:	Host of the message
+ * @param seq:	Message identifier indicating a transfer sequence
+ * @param flags:	Flag for the message
+ */
+struct ti_sci_msg_hdr {
+	uint16_t type;
+	uint8_t host;
+	uint8_t seq;
+#define TI_SCI_MSG_FLAG(val)               (1 << (val))
+#define TI_SCI_FLAG_REQ_GENERIC_NORESPONSE 0x0
+#define TI_SCI_FLAG_REQ_ACK_ON_RECEIVED    TI_SCI_MSG_FLAG(0)
+#define TI_SCI_FLAG_REQ_ACK_ON_PROCESSED   TI_SCI_MSG_FLAG(1)
+#define TI_SCI_FLAG_RESP_GENERIC_NACK      0x0
+#define TI_SCI_FLAG_RESP_GENERIC_ACK       TI_SCI_MSG_FLAG(1)
+	/* Additional Flags */
+	uint32_t flags;
+} __packed;
+
+/**
+ * @struct ti_sci_secure_msg_hdr
+ * @brief Header that prefixes all TISCI messages sent
+ *				  via secure transport.
+ * @param checksum:	crc16 checksum for the entire message
+ * @param reserved:	Reserved for future use.
+ */
+struct ti_sci_secure_msg_hdr {
+	uint16_t checksum;
+	uint16_t reserved;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_resp_version
+ * @brief Response for a message
+ *
+ * In general, ABI version changes follow the rule that minor version increments
+ * are backward compatible. Major revision changes in ABI may not be
+ * backward compatible.
+ *
+ * Response to a generic message with message type TI_SCI_MSG_VERSION
+ * @param hdr:		Generic header
+ * @param firmware_description: String describing the firmware
+ * @param firmware_revision:	Firmware revision
+ * @param abi_major:		Major version of the ABI that firmware supports
+ * @param abi_minor:		Minor version of the ABI that firmware supports
+ */
+struct ti_sci_msg_resp_version {
+	struct ti_sci_msg_hdr hdr;
+	char firmware_description[32];
+	uint16_t firmware_revision;
+	uint8_t abi_major;
+	uint8_t abi_minor;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_reboot
+ * @brief Reboot the SoC
+ * @param hdr:	Generic Header
+ * @param domain:	Domain to be reset, 0 for full SoC reboot.
+ *
+ * Request type is TI_SCI_MSG_SYS_RESET, responded with a generic
+ * ACK/NACK message.
+ */
+struct ti_sci_msg_req_reboot {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t domain;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_board_config
+ * @brief Board configuration message
+ * @param hdr:		Generic Header
+ * @param boardcfgp_low:	Lower 32 bit of the pointer pointing to the board
+ *			configuration data
+ * @param boardcfgp_high:	Upper 32 bit of the pointer pointing to the board
+ *			configuration data
+ * @param boardcfg_size:	Size of board configuration data object
+ * Request type is TI_SCI_MSG_BOARD_CONFIG, responded with a generic
+ * ACK/NACK message.
+ */
+struct ti_sci_msg_board_config {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t boardcfgp_low;
+	uint32_t boardcfgp_high;
+	uint16_t boardcfg_size;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_resp_query_msmc
+ * @brief Query msmc message response structure
+ * @param hdr:		Generic Header
+ * @param msmc_start_low:	Lower 32 bit of msmc start
+ * @param msmc_start_high:	Upper 32 bit of msmc start
+ * @param msmc_end_low:	Lower 32 bit of msmc end
+ * @param msmc_end_high:	Upper 32 bit of msmc end
+ *
+ * @brief Response to a generic message with message type TISCI_MSG_QUERY_MSMC
+ */
+struct ti_sci_msg_resp_query_msmc {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t msmc_start_low;
+	uint32_t msmc_start_high;
+	uint32_t msmc_end_low;
+	uint32_t msmc_end_high;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_set_device_state
+ * @brief Set the desired state of the device
+ * @param hdr:		Generic header
+ * @param id:	Indicates which device to modify
+ * @param reserved: Reserved space in message, must be 0 for backward compatibility
+ * @param state: The desired state of the device.
+ *
+ * Certain flags can also be set to alter the device state:
+ *  MSG_FLAG_DEVICE_WAKE_ENABLED - Configure the device to be a wake source.
+ * The meaning of this flag will vary slightly from device to device and from
+ * SoC to SoC but it generally allows the device to wake the SoC out of deep
+ * suspend states.
+ *  MSG_FLAG_DEVICE_RESET_ISO - Enable reset isolation for this device.
+ *  MSG_FLAG_DEVICE_EXCLUSIVE - Claim this device exclusively. When passed
+ * with STATE_RETENTION or STATE_ON, it will claim the device exclusively.
+ * If another host already has this device set to STATE_RETENTION or STATE_ON,
+ * the message will fail. Once successful, other hosts attempting to set
+ * STATE_RETENTION or STATE_ON will fail.
+ *
+ * Request type is TI_SCI_MSG_SET_DEVICE_STATE, responded with a generic
+ * ACK/NACK message.
+ */
+struct ti_sci_msg_req_set_device_state {
+	/* Additional hdr->flags options */
+#define MSG_FLAG_DEVICE_WAKE_ENABLED TI_SCI_MSG_FLAG(8)
+#define MSG_FLAG_DEVICE_RESET_ISO    TI_SCI_MSG_FLAG(9)
+#define MSG_FLAG_DEVICE_EXCLUSIVE    TI_SCI_MSG_FLAG(10)
+	struct ti_sci_msg_hdr hdr;
+	uint32_t id;
+	uint32_t reserved;
+
+#define MSG_DEVICE_SW_STATE_AUTO_OFF  0
+#define MSG_DEVICE_SW_STATE_RETENTION 1
+#define MSG_DEVICE_SW_STATE_ON        2
+	uint8_t state;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_get_device_state
+ * @brief Request to get device.
+ * @param hdr:		Generic header
+ * @param id:		Device Identifier
+ *
+ * Request type is TI_SCI_MSG_GET_DEVICE_STATE, responded device state
+ * information
+ */
+struct ti_sci_msg_req_get_device_state {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_resp_get_device_state
+ * @brief Response to get device request.
+ * @param hdr:		Generic header
+ * @param context_loss_count: Indicates how many times the device has lost context. A
+ *	driver can use this monotonic counter to determine if the device has
+ *	lost context since the last time this message was exchanged.
+ * @param resets: Programmed state of the reset lines.
+ * @param programmed_state:	The state as programmed by set_device.
+ *			- Uses the MSG_DEVICE_SW_* macros
+ * @param current_state:	The actual state of the hardware.
+ *
+ * Response to request TI_SCI_MSG_GET_DEVICE_STATE.
+ */
+struct ti_sci_msg_resp_get_device_state {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t context_loss_count;
+	uint32_t resets;
+	uint8_t programmed_state;
+#define MSG_DEVICE_HW_STATE_OFF   0
+#define MSG_DEVICE_HW_STATE_ON    1
+#define MSG_DEVICE_HW_STATE_TRANS 2
+	uint8_t current_state;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_set_device_reset
+ * @brief Set the desired resets configuration of the device
+ * @param hdr:		Generic header
+ * @param id:	Indicates which device to modify
+ * @param resets: A bit field of resets for the device. The meaning, behavior,
+ *	and usage of the reset flags are device specific. 0 for a bit
+ *	indicates releasing the reset represented by that bit while 1
+ *	indicates keeping it held.
+ *
+ * Request type is TI_SCI_MSG_SET_DEVICE_RESETS, responded with a generic
+ * ACK/NACK message.
+ */
+struct ti_sci_msg_req_set_device_resets {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t id;
+	uint32_t resets;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_set_clock_state
+ * @brief Request to setup a Clock state
+ * @param hdr:	Generic Header, Certain flags can be set specific to the clocks:
+ *		MSG_FLAG_CLOCK_ALLOW_SSC: Allow this clock to be modified
+ *		via spread spectrum clocking.
+ *		MSG_FLAG_CLOCK_ALLOW_FREQ_CHANGE: Allow this clock's
+ *		frequency to be changed while it is running so long as it
+ *		is within the min/max limits.
+ *		MSG_FLAG_CLOCK_INPUT_TERM: Enable input termination, this
+ *		is only applicable to clock inputs on the SoC pseudo-device.
+ * @param dev_id:	Device identifier this request is for
+ * @param clk_id:	Clock identifier for the device for this request.
+ *		Each device has it's own set of clock inputs. This indexes
+ *		which clock input to modify.
+ * @param request_state: Request the state for the clock to be set to.
+ *		MSG_CLOCK_SW_STATE_UNREQ: The IP does not require this clock,
+ *		it can be disabled, regardless of the state of the device
+ *		MSG_CLOCK_SW_STATE_AUTO: Allow the System Controller to
+ *		automatically manage the state of this clock. If the device
+ *		is enabled, then the clock is enabled. If the device is set
+ *		to off or retention, then the clock is internally set as not
+ *		being required by the device.(default)
+ *		MSG_CLOCK_SW_STATE_REQ:  Configure the clock to be enabled,
+ *		regardless of the state of the device.
+ *
+ * Normally, all required clocks are managed by TISCI entity, this is used
+ * only for specific control *IF* required. Auto managed state is
+ * MSG_CLOCK_SW_STATE_AUTO, in other states, TISCI entity assume remote
+ * will explicitly control.
+ *
+ * Request type is TI_SCI_MSG_SET_CLOCK_STATE, response is a generic
+ * ACK or NACK message.
+ */
+struct ti_sci_msg_req_set_clock_state {
+	/* Additional hdr->flags options */
+#define MSG_FLAG_CLOCK_ALLOW_SSC         TI_SCI_MSG_FLAG(8)
+#define MSG_FLAG_CLOCK_ALLOW_FREQ_CHANGE TI_SCI_MSG_FLAG(9)
+#define MSG_FLAG_CLOCK_INPUT_TERM        TI_SCI_MSG_FLAG(10)
+	struct ti_sci_msg_hdr hdr;
+	uint32_t dev_id;
+	uint8_t clk_id;
+#define MSG_CLOCK_SW_STATE_UNREQ 0
+#define MSG_CLOCK_SW_STATE_AUTO  1
+#define MSG_CLOCK_SW_STATE_REQ   2
+	uint8_t request_state;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_get_clock_state
+ * @brief Request for clock state
+ * @param hdr:	Generic Header
+ * @param dev_id:	Device identifier this request is for
+ * @param clk_id:	Clock identifier for the device for this request.
+ *		Each device has it's own set of clock inputs. This indexes
+ *		which clock input to get state of.
+ *
+ * Request type is TI_SCI_MSG_GET_CLOCK_STATE, response is state
+ * of the clock
+ */
+struct ti_sci_msg_req_get_clock_state {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t dev_id;
+	uint8_t clk_id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_resp_get_clock_state
+ * @brief Response to get clock state
+ * @param hdr:	Generic Header
+ * @param programmed_state: Any programmed state of the clock. This is one of
+ *		MSG_CLOCK_SW_STATE* values.
+ * @param current_state: Current state of the clock. This is one of:
+ *		MSG_CLOCK_HW_STATE_NOT_READY: Clock is not ready
+ *		MSG_CLOCK_HW_STATE_READY: Clock is ready
+ *
+ * Response to TI_SCI_MSG_GET_CLOCK_STATE.
+ */
+struct ti_sci_msg_resp_get_clock_state {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t programmed_state;
+#define MSG_CLOCK_HW_STATE_NOT_READY 0
+#define MSG_CLOCK_HW_STATE_READY     1
+	uint8_t current_state;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_set_clock_parent
+ * @brief Set the clock parent
+ * @param hdr:	Generic Header
+ * @param dev_id:	Device identifier this request is for
+ * @param clk_id:	Clock identifier for the device for this request.
+ *		Each device has it's own set of clock inputs. This indexes
+ *		which clock input to modify.
+ * @param parent_id:	The new clock parent is selectable by an index via this
+ *		parameter.
+ *
+ * Request type is TI_SCI_MSG_SET_CLOCK_PARENT, response is generic
+ * ACK / NACK message.
+ */
+struct ti_sci_msg_req_set_clock_parent {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t dev_id;
+	uint8_t clk_id;
+	uint8_t parent_id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_get_clock_parent
+ * @brief Get the clock parent
+ * @param hdr:	Generic Header
+ * @param dev_id:	Device identifier this request is for
+ * @param clk_id:	Clock identifier for the device for this request.
+ *		Each device has it's own set of clock inputs. This indexes
+ *		which clock input to get the parent for.
+ *
+ * Request type is TI_SCI_MSG_GET_CLOCK_PARENT, response is parent information
+ */
+struct ti_sci_msg_req_get_clock_parent {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t dev_id;
+	uint8_t clk_id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_resp_get_clock_parent
+ * @brief Response with clock parent
+ * @param hdr:	Generic Header
+ * @param parent_id:	The current clock parent
+ *
+ * Response to TI_SCI_MSG_GET_CLOCK_PARENT.
+ */
+struct ti_sci_msg_resp_get_clock_parent {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t parent_id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_get_clock_num_parents
+ * @brief Request to get clock parents
+ * @param hdr:	Generic header
+ * @param dev_id:	Device identifier this request is for
+ * @param clk_id:	Clock identifier for the device for this request.
+ *
+ * This request provides information about how many clock parent options
+ * are available for a given clock to a device. This is typically used
+ * for input clocks.
+ *
+ * Request type is TI_SCI_MSG_GET_NUM_CLOCK_PARENTS, response is appropriate
+ * message, or NACK in case of inability to satisfy request.
+ */
+struct ti_sci_msg_req_get_clock_num_parents {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t dev_id;
+	uint8_t clk_id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_resp_get_clock_num_parents
+ * @brief Response for get clk parents
+ * @param hdr:		Generic header
+ * @param num_parents:	Number of clock parents
+ *
+ * Response to TI_SCI_MSG_GET_NUM_CLOCK_PARENTS
+ */
+struct ti_sci_msg_resp_get_clock_num_parents {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t num_parents;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_query_clock_freq
+ * @brief Request to query a frequency
+ * @param hdr:	Generic Header
+ * @param dev_id:	Device identifier this request is for
+ * @param min_freq_hz: The minimum allowable frequency in Hz. This is the minimum
+ *		allowable programmed frequency and does not account for clock
+ *		tolerances and jitter.
+ * @param target_freq_hz: The target clock frequency. A frequency will be found
+ *		as close to this target frequency as possible.
+ * @param max_freq_hz: The maximum allowable frequency in Hz. This is the maximum
+ *		allowable programmed frequency and does not account for clock
+ *		tolerances and jitter.
+ * @param clk_id:	Clock identifier for the device for this request.
+ *
+ * NOTE: Normally clock frequency management is automatically done by TISCI
+ * entity. In case of specific requests, TISCI evaluates capability to achieve
+ * requested frequency within provided range and responds with
+ * result message.
+ *
+ * Request type is TI_SCI_MSG_QUERY_CLOCK_FREQ, response is appropriate message,
+ * or NACK in case of inability to satisfy request.
+ */
+struct ti_sci_msg_req_query_clock_freq {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t dev_id;
+	uint64_t min_freq_hz;
+	uint64_t target_freq_hz;
+	uint64_t max_freq_hz;
+	uint8_t clk_id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_resp_query_clock_freq
+ * @brief Response to a clock frequency query
+ * @param hdr:	Generic Header
+ * @param freq_hz:	Frequency that is the best match in Hz.
+ *
+ * Response to request type TI_SCI_MSG_QUERY_CLOCK_FREQ. NOTE: if the request
+ * cannot be satisfied, the message will be of type NACK.
+ */
+struct ti_sci_msg_resp_query_clock_freq {
+	struct ti_sci_msg_hdr hdr;
+	uint64_t freq_hz;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_set_clock_freq
+ * @brief Request to setup a clock frequency
+ * @param hdr:	Generic Header
+ * @param dev_id:	Device identifier this request is for
+ * @param min_freq_hz: The minimum allowable frequency in Hz. This is the minimum
+ *		allowable programmed frequency and does not account for clock
+ *		tolerances and jitter.
+ * @param target_freq_hz: The target clock frequency. The clock will be programmed
+ *		at a rate as close to this target frequency as possible.
+ * @param max_freq_hz: The maximum allowable frequency in Hz. This is the maximum
+ *		allowable programmed frequency and does not account for clock
+ *		tolerances and jitter.
+ * @param clk_id:	Clock identifier for the device for this request.
+ *
+ * NOTE: Normally clock frequency management is automatically done by TISCI
+ * entity. In case of specific requests, TISCI evaluates capability to achieve
+ * requested range and responds with success/failure message.
+ *
+ * This sets the desired frequency for a clock within an allowable
+ * range. This message will fail on an enabled clock unless
+ * MSG_FLAG_CLOCK_ALLOW_FREQ_CHANGE is set for the clock. Additionally,
+ * if other clocks have their frequency modified due to this message,
+ * they also must have the MSG_FLAG_CLOCK_ALLOW_FREQ_CHANGE or be disabled.
+ *
+ * Calling set frequency on a clock input to the SoC pseudo-device will
+ * inform the PMMC of that clock's frequency. Setting a frequency of
+ * zero will indicate the clock is disabled.
+ *
+ * Calling set frequency on clock outputs from the SoC pseudo-device will
+ * function similarly to setting the clock frequency on a device.
+ *
+ * Request type is TI_SCI_MSG_SET_CLOCK_FREQ, response is a generic ACK/NACK
+ * message.
+ */
+struct ti_sci_msg_req_set_clock_freq {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t dev_id;
+	uint64_t min_freq_hz;
+	uint64_t target_freq_hz;
+	uint64_t max_freq_hz;
+	uint8_t clk_id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_get_clock_freq
+ * @brief Request to get the clock frequency
+ * @param hdr:	Generic Header
+ * @param dev_id:	Device identifier this request is for
+ * @param clk_id:	Clock identifier for the device for this request.
+ *
+ * NOTE: Normally clock frequency management is automatically done by TISCI
+ * entity. In some cases, clock frequencies are configured by host.
+ *
+ * Request type is TI_SCI_MSG_GET_CLOCK_FREQ, responded with clock frequency
+ * that the clock is currently at.
+ */
+struct ti_sci_msg_req_get_clock_freq {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t dev_id;
+	uint8_t clk_id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_resp_get_clock_freq
+ * @brief Response of clock frequency request
+ * @param hdr:	Generic Header
+ * @param freq_hz:	Frequency that the clock is currently on, in Hz.
+ *
+ * Response to request type TI_SCI_MSG_GET_CLOCK_FREQ.
+ */
+struct ti_sci_msg_resp_get_clock_freq {
+	struct ti_sci_msg_hdr hdr;
+	uint64_t freq_hz;
+} __packed;
+
+#define TI_SCI_IRQ_SECONDARY_HOST_INVALID 0xff
+
+/**
+ * @struct ti_sci_msg_req_get_resource_range
+ * @brief Request to get a host's assigned
+ *					      range of resources.
+ * @param hdr:		Generic Header
+ * @param type:		Unique resource assignment type
+ * @param subtype:		Resource assignment subtype within the resource type.
+ * @param secondary_host:	Host processing entity to which the resources are
+ *			allocated. This is required only when the destination
+ *			host id id different from ti sci interface host id,
+ *			else TI_SCI_IRQ_SECONDARY_HOST_INVALID can be passed.
+ *
+ * Request type is TI_SCI_MSG_GET_RESOURCE_RANGE. Responded with requested
+ * resource range which is of type TI_SCI_MSG_GET_RESOURCE_RANGE.
+ */
+struct ti_sci_msg_req_get_resource_range {
+	struct ti_sci_msg_hdr hdr;
+#define MSG_RM_RESOURCE_TYPE_MASK    GENMASK(9, 0)
+#define MSG_RM_RESOURCE_SUBTYPE_MASK GENMASK(5, 0)
+	uint16_t type;
+	uint8_t subtype;
+	uint8_t secondary_host;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_resp_get_resource_range
+ * @brief Response to resource get range.
+ * @param hdr:		Generic Header
+ * @param range_start:	Start index of the resource range.
+ * @param range_num:		Number of resources in the range.
+ *
+ * Response to request TI_SCI_MSG_GET_RESOURCE_RANGE.
+ */
+struct ti_sci_msg_resp_get_resource_range {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t range_start;
+	uint16_t range_num;
+} __packed;
+#define GENMASK_ULL(h, l)     (((~0ULL) << (l)) & (~0ULL >> (BITS_PER_LONG_LONG - 1 - (h))))
+#define TISCI_ADDR_LOW_MASK   GENMASK_ULL(31, 0)
+#define TISCI_ADDR_HIGH_MASK  GENMASK_ULL(63, 32)
+#define TISCI_ADDR_HIGH_SHIFT 32
+
+/**
+ * @struct ti_sci_msg_req_proc_request
+ * @brief Request a processor
+ *
+ * @param hdr:		Generic Header
+ * @param processor_id:	ID of processor
+ *
+ * Request type is TISCI_MSG_PROC_REQUEST, response is a generic ACK/NACK
+ * message.
+ */
+struct ti_sci_msg_req_proc_request {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t processor_id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_proc_release
+ * @brief Release a processor
+ *
+ * @param hdr:		Generic Header
+ * @param processor_id:	ID of processor
+ *
+ * Request type is TISCI_MSG_PROC_RELEASE, response is a generic ACK/NACK
+ * message.
+ */
+struct ti_sci_msg_req_proc_release {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t processor_id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_proc_handover
+ * @brief Handover a processor to a host
+ *
+ * @param hdr:		Generic Header
+ * @param processor_id:	ID of processor
+ * @param host_id:		New Host we want to give control to
+ *
+ * Request type is TISCI_MSG_PROC_HANDOVER, response is a generic ACK/NACK
+ * message.
+ */
+struct ti_sci_msg_req_proc_handover {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t processor_id;
+	uint8_t host_id;
+} __packed;
+
+/* A53 Config Flags */
+#define PROC_BOOT_CFG_FLAG_ARMV8_DBG_EN      0x00000001
+#define PROC_BOOT_CFG_FLAG_ARMV8_DBG_NIDEN   0x00000002
+#define PROC_BOOT_CFG_FLAG_ARMV8_DBG_SPIDEN  0x00000004
+#define PROC_BOOT_CFG_FLAG_ARMV8_DBG_SPNIDEN 0x00000008
+#define PROC_BOOT_CFG_FLAG_ARMV8_AARCH32     0x00000100
+
+/* R5 Config Flags */
+#define PROC_BOOT_CFG_FLAG_R5_DBG_EN      0x00000001
+#define PROC_BOOT_CFG_FLAG_R5_DBG_NIDEN   0x00000002
+#define PROC_BOOT_CFG_FLAG_R5_LOCKSTEP    0x00000100
+#define PROC_BOOT_CFG_FLAG_R5_TEINIT      0x00000200
+#define PROC_BOOT_CFG_FLAG_R5_NMFI_EN     0x00000400
+#define PROC_BOOT_CFG_FLAG_R5_TCM_RSTBASE 0x00000800
+#define PROC_BOOT_CFG_FLAG_R5_BTCM_EN     0x00001000
+#define PROC_BOOT_CFG_FLAG_R5_ATCM_EN     0x00002000
+
+/**
+ * @struct ti_sci_msg_req_set_proc_boot_config
+ * @brief Set Processor boot configuration
+ * @param hdr:		Generic Header
+ * @param processor_id:	ID of processor
+ * @param bootvector_low:	Lower 32bit (Little Endian) of boot vector
+ * @param bootvector_high:	Higher 32bit (Little Endian) of boot vector
+ * @param config_flags_set:	Optional Processor specific Config Flags to set.
+ *			Setting a bit here implies required bit sets to 1.
+ * @param config_flags_clear:	Optional Processor specific Config Flags to clear.
+ *			Setting a bit here implies required bit gets cleared.
+ *
+ * Request type is TISCI_MSG_SET_PROC_BOOT_CONFIG, response is a generic
+ * ACK/NACK message.
+ */
+struct ti_sci_msg_req_set_proc_boot_config {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t processor_id;
+	uint32_t bootvector_low;
+	uint32_t bootvector_high;
+	uint32_t config_flags_set;
+	uint32_t config_flags_clear;
+} __packed;
+
+/* R5 Control Flags */
+#define PROC_BOOT_CTRL_FLAG_R5_CORE_HALT 0x00000001
+
+/**
+ * @struct ti_sci_msg_req_set_proc_boot_ctrl
+ * @brief Set Processor boot control flags
+ * @param hdr:		Generic Header
+ * @param processor_id:	ID of processor
+ * @param control_flags_set:	Optional Processor specific Control Flags to set.
+ *			Setting a bit here implies required bit sets to 1.
+ * @param control_flags_clear:Optional Processor specific Control Flags to clear.
+ *			Setting a bit here implies required bit gets cleared.
+ *
+ * Request type is TISCI_MSG_SET_PROC_BOOT_CTRL, response is a generic ACK/NACK
+ * message.
+ */
+struct ti_sci_msg_req_set_proc_boot_ctrl {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t processor_id;
+	uint32_t control_flags_set;
+	uint32_t control_flags_clear;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_proc_auth_start_image
+ * @brief Authenticate and start image
+ * @param hdr:		Generic Header
+ * @param cert_addr_low:	Lower 32bit (Little Endian) of certificate
+ * @param cert_addr_high:	Higher 32bit (Little Endian) of certificate
+ *
+ * Request type is TISCI_MSG_PROC_AUTH_BOOT_IMAGE, response is a generic
+ * ACK/NACK message.
+ */
+struct ti_sci_msg_req_proc_auth_boot_image {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t cert_addr_low;
+	uint32_t cert_addr_high;
+} __packed;
+
+struct ti_sci_msg_resp_proc_auth_boot_image {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t image_addr_low;
+	uint32_t image_addr_high;
+	uint32_t image_size;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_get_proc_boot_status
+ * @brief Get processor boot status
+ * @param hdr:		Generic Header
+ * @param processor_id:	ID of processor
+ *
+ * Request type is TISCI_MSG_GET_PROC_BOOT_STATUS, response is appropriate
+ * message, or NACK in case of inability to satisfy request.
+ */
+struct ti_sci_msg_req_get_proc_boot_status {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t processor_id;
+} __packed;
+
+/* ARMv8 Status Flags */
+#define PROC_BOOT_STATUS_FLAG_ARMV8_WFE 0x00000001
+#define PROC_BOOT_STATUS_FLAG_ARMV8_WFI 0x00000002
+
+/* R5 Status Flags */
+#define PROC_BOOT_STATUS_FLAG_R5_WFE                0x00000001
+#define PROC_BOOT_STATUS_FLAG_R5_WFI                0x00000002
+#define PROC_BOOT_STATUS_FLAG_R5_CLK_GATED          0x00000004
+#define PROC_BOOT_STATUS_FLAG_R5_LOCKSTEP_PERMITTED 0x00000100
+
+/**
+ * @struct ti_sci_msg_resp_get_proc_boot_status
+ * @brief Processor boot status response
+ * @param hdr:		Generic Header
+ * @param processor_id:	ID of processor
+ * @param bootvector_low:	Lower 32bit (Little Endian) of boot vector
+ * @param bootvector_high:	Higher 32bit (Little Endian) of boot vector
+ * @param config_flags:	Optional Processor specific Config Flags set.
+ * @param control_flags:	Optional Processor specific Control Flags.
+ * @param status_flags:	Optional Processor specific Status Flags set.
+ *
+ * Response to TISCI_MSG_GET_PROC_BOOT_STATUS.
+ */
+struct ti_sci_msg_resp_get_proc_boot_status {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t processor_id;
+	uint32_t bootvector_low;
+	uint32_t bootvector_high;
+	uint32_t config_flags;
+	uint32_t control_flags;
+	uint32_t status_flags;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_req_wait_proc_boot_status
+ * @brief Wait for a processor boot status
+ * @param hdr:			Generic Header
+ * @param processor_id:		ID of processor
+ * @param num_wait_iterations:	Total number of iterations we will check before
+ *				we will timeout and give up
+ * @param num_match_iterations:	How many iterations should we have continued
+ *				status to account for status bits glitching.
+ *				This is to make sure that match occurs for
+ *				consecutive checks. This implies that the
+ *				worst case should consider that the stable
+ *				time should at the worst be num_wait_iterations
+ *				num_match_iterations to prevent timeout.
+ * @param delay_per_iteration_us:	Specifies how long to wait (in micro seconds)
+ *				between each status checks. This is the minimum
+ *				duration, and overhead of register reads and
+ *				checks are on top of this and can vary based on
+ *				varied conditions.
+ * @param delay_before_iterations_us:	Specifies how long to wait (in micro seconds)
+ *				before the very first check in the first
+ *				iteration of status check loop. This is the
+ *				minimum duration, and overhead of register
+ *				reads and checks are.
+ * @param status_flags_1_set_all_wait:If non-zero, Specifies that all bits of the
+ *				status matching this field requested MUST be 1.
+ * @param status_flags_1_set_any_wait:If non-zero, Specifies that at least one of the
+ *				bits matching this field requested MUST be 1.
+ * @param status_flags_1_clr_all_wait:If non-zero, Specifies that all bits of the
+ *				status matching this field requested MUST be 0.
+ * @param status_flags_1_clr_any_wait:If non-zero, Specifies that at least one of the
+ *				bits matching this field requested MUST be 0.
+ *
+ * Request type is TISCI_MSG_WAIT_PROC_BOOT_STATUS, response is appropriate
+ * message, or NACK in case of inability to satisfy request.
+ */
+struct ti_sci_msg_req_wait_proc_boot_status {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t processor_id;
+	uint8_t num_wait_iterations;
+	uint8_t num_match_iterations;
+	uint8_t delay_per_iteration_us;
+	uint8_t delay_before_iterations_us;
+	uint32_t status_flags_1_set_all_wait;
+	uint32_t status_flags_1_set_any_wait;
+	uint32_t status_flags_1_clr_all_wait;
+	uint32_t status_flags_1_clr_any_wait;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_rm_ring_cfg_req
+ * @brief Configure a Navigator Subsystem ring
+ *
+ * Configures the non-real-time registers of a Navigator Subsystem ring.
+ * @param hdr:	Generic Header
+ * @param valid_params: Bitfield defining validity of ring configuration parameters.
+ *	The ring configuration fields are not valid, and will not be used for
+ *	ring configuration, if their corresponding valid bit is zero.
+ *	Valid bit usage:
+ *	0 - Valid bit for tisci_msg_rm_ring_cfg_req addr_lo
+ *	1 - Valid bit for tisci_msg_rm_ring_cfg_req addr_hi
+ *	2 - Valid bit for tisci_msg_rm_ring_cfg_req count
+ *	3 - Valid bit for tisci_msg_rm_ring_cfg_req mode
+ *	4 - Valid bit for tisci_msg_rm_ring_cfg_req size
+ *	5 - Valid bit for tisci_msg_rm_ring_cfg_req order_id
+ * @param nav_id: Device ID of Navigator Subsystem from which the ring is allocated
+ * @param index: ring index to be configured.
+ * @param addr_lo: 32 LSBs of ring base address to be programmed into the ring's
+ *	RING_BA_LO register
+ * @param addr_hi: 16 MSBs of ring base address to be programmed into the ring's
+ *	RING_BA_HI register.
+ * @param count: Number of ring elements. Must be even if mode is CREDENTIALS or QM
+ *	modes.
+ * @param mode: Specifies the mode the ring is to be configured.
+ * @param size: Specifies encoded ring element size. To calculate the encoded size use
+ *	the formula (log2(size_bytes) - 2), where size_bytes cannot be
+ *	greater than 256.
+ * @param order_id: Specifies the ring's bus order ID.
+ */
+struct ti_sci_msg_rm_ring_cfg_req {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t valid_params;
+	uint16_t nav_id;
+	uint16_t index;
+	uint32_t addr_lo;
+	uint32_t addr_hi;
+	uint32_t count;
+	uint8_t mode;
+	uint8_t size;
+	uint8_t order_id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_rm_ring_cfg_resp
+ * @brief Response to configuring a ring.
+ *
+ * @param hdr:	Generic Header
+ */
+struct ti_sci_msg_rm_ring_cfg_resp {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_rm_ring_get_cfg_req
+ * @brief Get RA ring's configuration
+ *
+ * Gets the configuration of the non-real-time register fields of a ring.  The
+ * host, or a supervisor of the host, who owns the ring must be the requesting
+ * host.  The values of the non-real-time registers are returned in
+ * ti_sci_msg_rm_ring_get_cfg_resp.
+ *
+ * @param hdr: Generic Header
+ * @param nav_id: Device ID of Navigator Subsystem from which the ring is allocated
+ * @param index: ring index.
+ */
+struct ti_sci_msg_rm_ring_get_cfg_req {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t nav_id;
+	uint16_t index;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_rm_ring_get_cfg_resp
+ * @brief  Ring get configuration response
+ *
+ * Response received by host processor after RM has handled
+ * @ref ti_sci_msg_rm_ring_get_cfg_req. The response contains the ring's
+ * non-real-time register values.
+ *
+ * @param hdr: Generic Header
+ * @param addr_lo: Ring 32 LSBs of base address
+ * @param addr_hi: Ring 16 MSBs of base address.
+ * @param count: Ring number of elements.
+ * @param mode: Ring mode.
+ * @param size: encoded Ring element size
+ * @param order_id: ing order ID.
+ */
+struct ti_sci_msg_rm_ring_get_cfg_resp {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t addr_lo;
+	uint32_t addr_hi;
+	uint32_t count;
+	uint8_t mode;
+	uint8_t size;
+	uint8_t order_id;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_psil_pair
+ * @brief Pairs a PSI-L source thread to a destination
+ *				 thread
+ * @param hdr:	Generic Header
+ * @param nav_id:	SoC Navigator Subsystem device ID whose PSI-L config proxy is
+ *		used to pair the source and destination threads.
+ * @param src_thread:	PSI-L source thread ID within the PSI-L System thread map.
+ *
+ * UDMAP transmit channels mapped to source threads will have their
+ * TCHAN_THRD_ID register programmed with the destination thread if the pairing
+ * is successful.
+
+ * @param dst_thread: PSI-L destination thread ID within the PSI-L System thread map.
+ * PSI-L destination threads start at index 0x8000.  The request is NACK'd if
+ * the destination thread is not greater than or equal to 0x8000.
+ *
+ * UDMAP receive channels mapped to destination threads will have their
+ * RCHAN_THRD_ID register programmed with the source thread if the pairing
+ * is successful.
+ *
+ * Request type is TI_SCI_MSG_RM_PSIL_PAIR, response is a generic ACK or NACK
+ * message.
+ */
+struct ti_sci_msg_psil_pair {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t nav_id;
+	uint32_t src_thread;
+	uint32_t dst_thread;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_psil_unpair
+ * @brief Unpairs a PSI-L source thread from a destination thread
+ * @param hdr:	Generic Header
+ * @param nav_id:	SoC Navigator Subsystem device ID whose PSI-L config proxy is
+ *		used to unpair the source and destination threads.
+ * @param src_thread:	PSI-L source thread ID within the PSI-L System thread map.
+ *
+ * UDMAP transmit channels mapped to source threads will have their
+ * TCHAN_THRD_ID register cleared if the unpairing is successful.
+ *
+ * @param dst_thread: PSI-L destination thread ID within the PSI-L System thread map.
+ * PSI-L destination threads start at index 0x8000.  The request is NACK'd if
+ * the destination thread is not greater than or equal to 0x8000.
+ *
+ * UDMAP receive channels mapped to destination threads will have their
+ * RCHAN_THRD_ID register cleared if the unpairing is successful.
+ *
+ * Request type is TI_SCI_MSG_RM_PSIL_UNPAIR, response is a generic ACK or NACK
+ * message.
+ */
+struct ti_sci_msg_psil_unpair {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t nav_id;
+	uint32_t src_thread;
+	uint32_t dst_thread;
+} __packed;
+
+/**
+ * Configures a Navigator Subsystem UDMAP transmit channel
+ *
+ * Configures the non-real-time registers of a Navigator Subsystem UDMAP
+ * transmit channel.  The channel index must be assigned to the host defined
+ * in the TISCI header via the RM board configuration resource assignment
+ * range list.
+ *
+ * @param hdr: Generic Header
+ *
+ * @param valid_params: Bitfield defining validity of tx channel configuration
+ * parameters. The tx channel configuration fields are not valid, and will not
+ * be used for ch configuration, if their corresponding valid bit is zero.
+ * Valid bit usage:
+ *    0 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_pause_on_err
+ *    1 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_atype
+ *    2 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_chan_type
+ *    3 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_fetch_size
+ *    4 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::txcq_qnum
+ *    5 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_priority
+ *    6 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_qos
+ *    7 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_orderid
+ *    8 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_sched_priority
+ *    9 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_filt_einfo
+ *   10 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_filt_pswords
+ *   11 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_supr_tdpkt
+ *   12 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_credit_count
+ *   13 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::fdepth
+ *   14 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_burst_size
+ *   15 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::tx_tdtype
+ *   16 - Valid bit for ti_sci_msg_rm_udmap_tx_ch_cfg::extended_ch_type
+ *
+ * @param nav_id: SoC device ID of Navigator Subsystem where tx channel is located
+ *
+ * @param index: UDMAP transmit channel index.
+ *
+ * @param tx_pause_on_err: UDMAP transmit channel pause on error configuration to
+ * be programmed into the tx_pause_on_err field of the channel's TCHAN_TCFG
+ * register.
+ *
+ * @param tx_filt_einfo: UDMAP transmit channel extended packet information passing
+ * configuration to be programmed into the tx_filt_einfo field of the
+ * channel's TCHAN_TCFG register.
+ *
+ * @param tx_filt_pswords: UDMAP transmit channel protocol specific word passing
+ * configuration to be programmed into the tx_filt_pswords field of the
+ * channel's TCHAN_TCFG register.
+ *
+ * @param tx_atype: UDMAP transmit channel non Ring Accelerator access pointer
+ * interpretation configuration to be programmed into the tx_atype field of
+ * the channel's TCHAN_TCFG register.
+ *
+ * @param tx_chan_type: UDMAP transmit channel functional channel type and work
+ * passing mechanism configuration to be programmed into the tx_chan_type
+ * field of the channel's TCHAN_TCFG register.
+ *
+ * @param tx_supr_tdpkt: UDMAP transmit channel teardown packet generation suppression
+ * configuration to be programmed into the tx_supr_tdpkt field of the channel's
+ * TCHAN_TCFG register.
+ *
+ * @param tx_fetch_size: UDMAP transmit channel number of 32-bit descriptor words to
+ * fetch configuration to be programmed into the tx_fetch_size field of the
+ * channel's TCHAN_TCFG register.  The user must make sure to set the maximum
+ * word count that can pass through the channel for any allowed descriptor type.
+ *
+ * @param tx_credit_count: UDMAP transmit channel transfer request credit count
+ * configuration to be programmed into the count field of the TCHAN_TCREDIT
+ * register.  Specifies how many credits for complete TRs are available.
+ *
+ * @param txcq_qnum: UDMAP transmit channel completion queue configuration to be
+ * programmed into the txcq_qnum field of the TCHAN_TCQ register. The specified
+ * completion queue must be assigned to the host, or a subordinate of the host,
+ * requesting configuration of the transmit channel.
+ *
+ * @param tx_priority: UDMAP transmit channel transmit priority value to be programmed
+ * into the priority field of the channel's TCHAN_TPRI_CTRL register.
+ *
+ * @param tx_qos: UDMAP transmit channel transmit qos value to be programmed into the
+ * qos field of the channel's TCHAN_TPRI_CTRL register.
+ *
+ * @param tx_orderid: UDMAP transmit channel bus order id value to be programmed into
+ * the orderid field of the channel's TCHAN_TPRI_CTRL register.
+ *
+ * @param fdepth: UDMAP transmit channel FIFO depth configuration to be programmed
+ * into the fdepth field of the TCHAN_TFIFO_DEPTH register. Sets the number of
+ * Tx FIFO bytes which are allowed to be stored for the channel. Check the UDMAP
+ * section of the TRM for restrictions regarding this parameter.
+ *
+ * @param tx_sched_priority: UDMAP transmit channel tx scheduling priority
+ * configuration to be programmed into the priority field of the channel's
+ * TCHAN_TST_SCHED register.
+ *
+ * @param tx_burst_size: UDMAP transmit channel burst size configuration to be
+ * programmed into the tx_burst_size field of the TCHAN_TCFG register.
+ *
+ * @param tx_tdtype: UDMAP transmit channel teardown type configuration to be
+ * programmed into the tdtype field of the TCHAN_TCFG register:
+ * 0 - Return immediately
+ * 1 - Wait for completion message from remote peer
+ *
+ * @param extended_ch_type: Valid for BCDMA.
+ * 0 - the channel is split tx channel (tchan)
+ * 1 - the channel is block copy channel (bchan)
+ */
+struct ti_sci_msg_rm_udmap_tx_ch_cfg_req {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t valid_params;
+	uint16_t nav_id;
+	uint16_t index;
+	uint8_t tx_pause_on_err;
+	uint8_t tx_filt_einfo;
+	uint8_t tx_filt_pswords;
+	uint8_t tx_atype;
+	uint8_t tx_chan_type;
+	uint8_t tx_supr_tdpkt;
+	uint16_t tx_fetch_size;
+	uint8_t tx_credit_count;
+	uint16_t txcq_qnum;
+	uint8_t tx_priority;
+	uint8_t tx_qos;
+	uint8_t tx_orderid;
+	uint16_t fdepth;
+	uint8_t tx_sched_priority;
+	uint8_t tx_burst_size;
+	uint8_t tx_tdtype;
+	uint8_t extended_ch_type;
+} __packed;
+
+/**
+ *  Response to configuring a UDMAP transmit channel.
+ *
+ * @param hdr: Standard TISCI header
+ */
+struct ti_sci_msg_rm_udmap_tx_ch_cfg_resp {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
+ * Configures a Navigator Subsystem UDMAP receive channel
+ *
+ * Configures the non-real-time registers of a Navigator Subsystem UDMAP
+ * receive channel.  The channel index must be assigned to the host defined
+ * in the TISCI header via the RM board configuration resource assignment
+ * range list.
+ *
+ * @param hdr: Generic Header
+ *
+ * @param valid_params: Bitfield defining validity of rx channel configuration
+ * parameters.
+ * The rx channel configuration fields are not valid, and will not be used for
+ * ch configuration, if their corresponding valid bit is zero.
+ * Valid bit usage:
+ *    0 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::rx_pause_on_err
+ *    1 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::rx_atype
+ *    2 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::rx_chan_type
+ *    3 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::rx_fetch_size
+ *    4 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::rxcq_qnum
+ *    5 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::rx_priority
+ *    6 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::rx_qos
+ *    7 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::rx_orderid
+ *    8 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::rx_sched_priority
+ *    9 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::flowid_start
+ *   10 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::flowid_cnt
+ *   11 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::rx_ignore_short
+ *   12 - Valid bit for @ref ti_sci_msg_rm_udmap_rx_ch_cfg_req::rx_ignore_long
+ *
+ * @param nav_id: SoC device ID of Navigator Subsystem where rx channel is located
+ *
+ * @param index: UDMAP receive channel index.
+ *
+ * @param rx_fetch_size: UDMAP receive channel number of 32-bit descriptor words to
+ * fetch configuration to be programmed into the rx_fetch_size field of the
+ * channel's RCHAN_RCFG register.
+ *
+ * @param rxcq_qnum: UDMAP receive channel completion queue configuration to be
+ * programmed into the rxcq_qnum field of the RCHAN_RCQ register.
+ * The specified completion queue must be assigned to the host, or a subordinate
+ * of the host, requesting configuration of the receive channel.
+ *
+ * @param rx_priority: UDMAP receive channel receive priority value to be programmed
+ * into the priority field of the channel's RCHAN_RPRI_CTRL register.
+ *
+ * @param rx_qos: UDMAP receive channel receive qos value to be programmed into the
+ * qos field of the channel's RCHAN_RPRI_CTRL register.
+ *
+ * @param rx_orderid: UDMAP receive channel bus order id value to be programmed into
+ * the orderid field of the channel's RCHAN_RPRI_CTRL register.
+ *
+ * @param rx_sched_priority: UDMAP receive channel rx scheduling priority
+ * configuration to be programmed into the priority field of the channel's
+ * RCHAN_RST_SCHED register.
+ *
+ * @param flowid_start: UDMAP receive channel additional flows starting index
+ * configuration to program into the flow_start field of the RCHAN_RFLOW_RNG
+ * register. Specifies the starting index for flow IDs the receive channel is to
+ * make use of beyond the default flow. flowid_start and @ref flowid_cnt must be
+ * set as valid and configured together. The starting flow ID set by
+ * @ref flowid_cnt must be a flow index within the Navigator Subsystem's subset
+ * of flows beyond the default flows statically mapped to receive channels.
+ * The additional flows must be assigned to the host, or a subordinate of the
+ * host, requesting configuration of the receive channel.
+ *
+ * @param flowid_cnt: UDMAP receive channel additional flows count configuration to
+ * program into the flowid_cnt field of the RCHAN_RFLOW_RNG register.
+ * This field specifies how many flow IDs are in the additional contiguous range
+ * of legal flow IDs for the channel.  @ref flowid_start and flowid_cnt must be
+ * set as valid and configured together. Disabling the valid_params field bit
+ * for flowid_cnt indicates no flow IDs other than the default are to be
+ * allocated and used by the receive channel. @ref flowid_start plus flowid_cnt
+ * cannot be greater than the number of receive flows in the receive channel's
+ * Navigator Subsystem.  The additional flows must be assigned to the host, or a
+ * subordinate of the host, requesting configuration of the receive channel.
+ *
+ * @param rx_pause_on_err: UDMAP receive channel pause on error configuration to be
+ * programmed into the rx_pause_on_err field of the channel's RCHAN_RCFG
+ * register.
+ *
+ * @param rx_atype: UDMAP receive channel non Ring Accelerator access pointer
+ * interpretation configuration to be programmed into the rx_atype field of the
+ * channel's RCHAN_RCFG register.
+ *
+ * @param rx_chan_type: UDMAP receive channel functional channel type and work passing
+ * mechanism configuration to be programmed into the rx_chan_type field of the
+ * channel's RCHAN_RCFG register.
+ *
+ * @param rx_ignore_short: UDMAP receive channel short packet treatment configuration
+ * to be programmed into the rx_ignore_short field of the RCHAN_RCFG register.
+ *
+ * @param rx_ignore_long: UDMAP receive channel long packet treatment configuration to
+ * be programmed into the rx_ignore_long field of the RCHAN_RCFG register.
+ */
+struct ti_sci_msg_rm_udmap_rx_ch_cfg_req {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t valid_params;
+	uint16_t nav_id;
+	uint16_t index;
+	uint16_t rx_fetch_size;
+	uint16_t rxcq_qnum;
+	uint8_t rx_priority;
+	uint8_t rx_qos;
+	uint8_t rx_orderid;
+	uint8_t rx_sched_priority;
+	uint16_t flowid_start;
+	uint16_t flowid_cnt;
+	uint8_t rx_pause_on_err;
+	uint8_t rx_atype;
+	uint8_t rx_chan_type;
+	uint8_t rx_ignore_short;
+	uint8_t rx_ignore_long;
+} __packed;
+
+/**
+ * Response to configuring a UDMAP receive channel.
+ *
+ * @param hdr: Standard TISCI header
+ */
+struct ti_sci_msg_rm_udmap_rx_ch_cfg_resp {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
+ * Configures a Navigator Subsystem UDMAP receive flow
+ *
+ * Configures a Navigator Subsystem UDMAP receive flow's registers.
+ * Configuration does not include the flow registers which handle size-based
+ * free descriptor queue routing.
+ *
+ * The flow index must be assigned to the host defined in the TISCI header via
+ * the RM board configuration resource assignment range list.
+ *
+ * @param hdr: Standard TISCI header
+ *
+ * Valid params
+ * Bitfield defining validity of rx flow configuration parameters.  The
+ * rx flow configuration fields are not valid, and will not be used for flow
+ * configuration, if their corresponding valid bit is zero.  Valid bit usage:
+ *     0 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_einfo_present
+ *     1 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_psinfo_present
+ *     2 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_error_handling
+ *     3 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_desc_type
+ *     4 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_sop_offset
+ *     5 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_dest_qnum
+ *     6 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_src_tag_hi
+ *     7 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_src_tag_lo
+ *     8 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_dest_tag_hi
+ *     9 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_dest_tag_lo
+ *    10 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_src_tag_hi_sel
+ *    11 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_src_tag_lo_sel
+ *    12 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_dest_tag_hi_sel
+ *    13 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_dest_tag_lo_sel
+ *    14 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_fdq0_sz0_qnum
+ *    15 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_fdq1_sz0_qnum
+ *    16 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_fdq2_sz0_qnum
+ *    17 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_fdq3_sz0_qnum
+ *    18 - Valid bit for reftisci_msg_rm_udmap_flow_cfg_req::rx_ps_location
+ *
+ * @param nav_id: SoC device ID of Navigator Subsystem from which the receive flow is
+ * allocated
+ *
+ * @param flow_index: UDMAP receive flow index for non-optional configuration.
+ *
+ * @param rx_einfo_present:
+ * UDMAP receive flow extended packet info present configuration to be
+ * programmed into the rx_einfo_present field of the flow's RFLOW_RFA register.
+ *
+ * @param rx_psinfo_present:
+ * UDMAP receive flow PS words present configuration to be programmed into the
+ * rx_psinfo_present field of the flow's RFLOW_RFA register.
+ *
+ * @param rx_error_handling:
+ * UDMAP receive flow error handling configuration to be programmed into the
+ * rx_error_handling field of the flow's RFLOW_RFA register.
+ *
+ * @param rx_desc_type:
+ * UDMAP receive flow descriptor type configuration to be programmed into the
+ * rx_desc_type field field of the flow's RFLOW_RFA register.
+ *
+ * @param rx_sop_offset:
+ * UDMAP receive flow start of packet offset configuration to be programmed
+ * into the rx_sop_offset field of the RFLOW_RFA register.  See the UDMAP
+ * section of the TRM for more information on this setting.  Valid values for
+ * this field are 0-255 bytes.
+ *
+ * @param rx_dest_qnum:
+ * UDMAP receive flow destination queue configuration to be programmed into the
+ * rx_dest_qnum field of the flow's RFLOW_RFA register.  The specified
+ * destination queue must be valid within the Navigator Subsystem and must be
+ * owned by the host, or a subordinate of the host, requesting allocation and
+ * configuration of the receive flow.
+ *
+ * @param rx_src_tag_hi:
+ * UDMAP receive flow source tag high byte constant configuration to be
+ * programmed into the rx_src_tag_hi field of the flow's RFLOW_RFB register.
+ * See the UDMAP section of the TRM for more information on this setting.
+ *
+ * @param rx_src_tag_lo:
+ * UDMAP receive flow source tag low byte constant configuration to be
+ * programmed into the rx_src_tag_lo field of the flow's RFLOW_RFB register.
+ * See the UDMAP section of the TRM for more information on this setting.
+ *
+ * @param rx_dest_tag_hi:
+ * UDMAP receive flow destination tag high byte constant configuration to be
+ * programmed into the rx_dest_tag_hi field of the flow's RFLOW_RFB register.
+ * See the UDMAP section of the TRM for more information on this setting.
+ *
+ * @param rx_dest_tag_lo:
+ * UDMAP receive flow destination tag low byte constant configuration to be
+ * programmed into the rx_dest_tag_lo field of the flow's RFLOW_RFB register.
+ * See the UDMAP section of the TRM for more information on this setting.
+ *
+ * @param rx_src_tag_hi_sel:
+ * UDMAP receive flow source tag high byte selector configuration to be
+ * programmed into the rx_src_tag_hi_sel field of the RFLOW_RFC register.  See
+ * the UDMAP section of the TRM for more information on this setting.
+ *
+ * @param rx_src_tag_lo_sel:
+ * UDMAP receive flow source tag low byte selector configuration to be
+ * programmed into the rx_src_tag_lo_sel field of the RFLOW_RFC register.  See
+ * the UDMAP section of the TRM for more information on this setting.
+ *
+ * @param rx_dest_tag_hi_sel:
+ * UDMAP receive flow destination tag high byte selector configuration to be
+ * programmed into the rx_dest_tag_hi_sel field of the RFLOW_RFC register.  See
+ * the UDMAP section of the TRM for more information on this setting.
+ *
+ * @param rx_dest_tag_lo_sel:
+ * UDMAP receive flow destination tag low byte selector configuration to be
+ * programmed into the rx_dest_tag_lo_sel field of the RFLOW_RFC register.  See
+ * the UDMAP section of the TRM for more information on this setting.
+ *
+ * @param rx_fdq0_sz0_qnum:
+ * UDMAP receive flow free descriptor queue 0 configuration to be programmed
+ * into the rx_fdq0_sz0_qnum field of the flow's RFLOW_RFD register.  See the
+ * UDMAP section of the TRM for more information on this setting. The specified
+ * free queue must be valid within the Navigator Subsystem and must be owned
+ * by the host, or a subordinate of the host, requesting allocation and
+ * configuration of the receive flow.
+ *
+ * @param rx_fdq1_qnum:
+ * UDMAP receive flow free descriptor queue 1 configuration to be programmed
+ * into the rx_fdq1_qnum field of the flow's RFLOW_RFD register.  See the
+ * UDMAP section of the TRM for more information on this setting.  The specified
+ * free queue must be valid within the Navigator Subsystem and must be owned
+ * by the host, or a subordinate of the host, requesting allocation and
+ * configuration of the receive flow.
+ *
+ * @param rx_fdq2_qnum:
+ * UDMAP receive flow free descriptor queue 2 configuration to be programmed
+ * into the rx_fdq2_qnum field of the flow's RFLOW_RFE register.  See the
+ * UDMAP section of the TRM for more information on this setting.  The specified
+ * free queue must be valid within the Navigator Subsystem and must be owned
+ * by the host, or a subordinate of the host, requesting allocation and
+ * configuration of the receive flow.
+ *
+ * @param rx_fdq3_qnum:
+ * UDMAP receive flow free descriptor queue 3 configuration to be programmed
+ * into the rx_fdq3_qnum field of the flow's RFLOW_RFE register.  See the
+ * UDMAP section of the TRM for more information on this setting.  The specified
+ * free queue must be valid within the Navigator Subsystem and must be owned
+ * by the host, or a subordinate of the host, requesting allocation and
+ * configuration of the receive flow.
+ *
+ * @param rx_ps_location:
+ * UDMAP receive flow PS words location configuration to be programmed into the
+ * rx_ps_location field of the flow's RFLOW_RFA register.
+ */
+struct ti_sci_msg_rm_udmap_flow_cfg_req {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t valid_params;
+	uint16_t nav_id;
+	uint16_t flow_index;
+	uint8_t rx_einfo_present;
+	uint8_t rx_psinfo_present;
+	uint8_t rx_error_handling;
+	uint8_t rx_desc_type;
+	uint16_t rx_sop_offset;
+	uint16_t rx_dest_qnum;
+	uint8_t rx_src_tag_hi;
+	uint8_t rx_src_tag_lo;
+	uint8_t rx_dest_tag_hi;
+	uint8_t rx_dest_tag_lo;
+	uint8_t rx_src_tag_hi_sel;
+	uint8_t rx_src_tag_lo_sel;
+	uint8_t rx_dest_tag_hi_sel;
+	uint8_t rx_dest_tag_lo_sel;
+	uint16_t rx_fdq0_sz0_qnum;
+	uint16_t rx_fdq1_qnum;
+	uint16_t rx_fdq2_qnum;
+	uint16_t rx_fdq3_qnum;
+	uint8_t rx_ps_location;
+} __packed;
+
+/**
+ *  Response to configuring a Navigator Subsystem UDMAP receive flow
+ *
+ * @param hdr: Standard TISCI header
+ */
+struct ti_sci_msg_rm_udmap_flow_cfg_resp {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+#define FWL_MAX_PRIVID_SLOTS 3U
+
+/**
+ * @struct ti_sci_msg_fwl_set_firewall_region_req
+ * @brief Request for configuring the firewall permissions.
+ *
+ * @param hdr:		Generic Header
+ *
+ * @param fwl_id:		Firewall ID in question
+ * @param region:		Region or channel number to set config info
+ *			This field is unused in case of a simple firewall  and must be initialized
+ *			to zero.  In case of a region based firewall, this field indicates the
+ *			region in question. (index starting from 0) In case of a channel based
+ *			firewall, this field indicates the channel in question (index starting
+ *			from 0)
+ * @param n_permission_regs:	Number of permission registers to set
+ * @param control:		Contents of the firewall CONTROL register to set
+ * @param permissions:	Contents of the firewall PERMISSION register to set
+ * @param start_address:	Contents of the firewall START_ADDRESS register to set
+ * @param end_address:	Contents of the firewall END_ADDRESS register to set
+ */
+
+struct ti_sci_msg_fwl_set_firewall_region_req {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+	uint32_t control;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS];
+	uint64_t start_address;
+	uint64_t end_address;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_fwl_get_firewall_region_req
+ * @brief Request for retrieving the firewall permissions
+ *
+ * @param hdr:		Generic Header
+ *
+ * @param fwl_id:		Firewall ID in question
+ * @param region:		Region or channel number to get config info
+ *			This field is unused in case of a simple firewall and must be initialized
+ *			to zero.  In case of a region based firewall, this field indicates the
+ *			region in question (index starting from 0). In case of a channel based
+ *			firewall, this field indicates the channel in question (index starting
+ *			from 0).
+ * @param n_permission_regs:	Number of permission registers to retrieve
+ */
+struct ti_sci_msg_fwl_get_firewall_region_req {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_fwl_get_firewall_region_resp
+ * @brief Response for retrieving the firewall permissions
+ *
+ * @param hdr:		Generic Header
+ *
+ * @param fwl_id:		Firewall ID in question
+ * @param region:		Region or channel number to set config info This field is
+ *			unused in case of a simple firewall  and must be initialized to zero.  In
+ *			case of a region based firewall, this field indicates the region in
+ *			question. (index starting from 0) In case of a channel based firewall, this
+ *			field indicates the channel in question (index starting from 0)
+ * @param n_permission_regs:	Number of permission registers retrieved
+ * @param control:		Contents of the firewall CONTROL register
+ * @param permissions:	Contents of the firewall PERMISSION registers
+ * @param start_address:	Contents of the firewall START_ADDRESS
+ * register This is not applicable for
+ * channelized firewalls.
+ * @param end_address:	Contents of the firewall END_ADDRESS register This is not applicable for
+ * channelized firewalls.
+ */
+struct ti_sci_msg_fwl_get_firewall_region_resp {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+	uint32_t control;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS];
+	uint64_t start_address;
+	uint64_t end_address;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_fwl_change_owner_info_req
+ * @brief Request for a firewall owner change
+ *
+ * @param hdr:		Generic Header
+ *
+ * @param fwl_id:		Firewall ID in question
+ * @param region:		Region or channel number if applicable
+ * @param owner_index:	New owner index to transfer ownership to
+ */
+struct ti_sci_msg_fwl_change_owner_info_req {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint8_t owner_index;
+} __packed;
+
+/**
+ * @struct ti_sci_msg_fwl_change_owner_info_resp
+ * @brief Response for a firewall owner change
+ *
+ * @param hdr:		Generic Header
+ *
+ * @param fwl_id:		Firewall ID specified in request
+ * @param region:		Region or channel number specified in request
+ * @param owner_index:	Owner index specified in request
+ * @param owner_privid:	New owner priv-ID returned by DMSC.
+ * @param owner_permission_bits:	New owner permission bits returned by DMSC.
+ */
+
+struct ti_sci_msg_fwl_change_owner_info_resp {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint8_t owner_index;
+	uint8_t owner_privid;
+	uint16_t owner_permission_bits;
+} __packed;
+
+/**
+ * @struct ti_sci_version_info
+ * @brief version information structure
+ * @param abi_major:	Major ABI version. Change here implies risk of backward
+ *		compatibility break.
+ * @param abi_minor:	Minor ABI version. Change here implies new feature addition,
+ *		or compatible change in ABI.
+ * @param firmware_revision:	Firmware revision (not usually used).
+ * @param firmware_description: Firmware description (not usually used).
+ */
+struct ti_sci_version_info {
+	uint8_t abi_major;
+	uint8_t abi_minor;
+	uint16_t firmware_revision;
+	char firmware_description[32];
+};
+
+struct ti_sci_desc {
+	int max_msg_size;
+};
+#endif /* INCLUDE_ZEPHYR_DRIVERS_MISC_TISCI_H_ */

--- a/dts/bindings/firmware/ti,k2g-sci.yaml
+++ b/dts/bindings/firmware/ti,k2g-sci.yaml
@@ -1,0 +1,25 @@
+# Copyright 2025 Texas Instruments Incorporated.
+# SPDX-License-Identifier: Apache-2.0
+
+description: TISCI Client Driver
+
+compatible: "ti,k2g-sci"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  ti,host-id:
+    type: int
+    required: true
+    description: Host ID for processor
+
+  mboxes:
+    description: phandle to the MBOX controller (TX and RX are required)
+    required: true
+
+  mbox-names:
+    description: MBOX channel names (must be called "tx" and "rx")
+    required: true

--- a/include/zephyr/drivers/firmware/tisci/ti_sci.h
+++ b/include/zephyr/drivers/firmware/tisci/ti_sci.h
@@ -1,0 +1,795 @@
+/*
+ * Copyright (c) 2025, Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Public APIs for the TISCI driver
+ *
+ */
+
+#ifndef INCLUDE_ZEPHYR_DRIVERS_TISCI_H_
+#define INCLUDE_ZEPHYR_DRIVERS_TISCI_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/firmware/tisci/tisci_protocol.h>
+
+/* Version/Revision Functions */
+
+/**
+ * @brief Get the revision of the SCI entity
+ *
+ * Updates the SCI information in the internal data structure.
+ *
+ * @param dev Pointer to the TI SCI device
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_get_revision(const struct device *dev);
+
+/* Clock Management Functions */
+
+/**
+ * @brief Get the state of a clock
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ * @param programmed_state Pointer to store the requested state of the clock
+ * @param current_state Pointer to store the current state of the clock
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_get_clock_state(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			       uint8_t *programmed_state, uint8_t *current_state);
+
+/**
+ * @brief Set the state of a clock
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ * @param flags Header flags as needed
+ * @param state State to request for the clock
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_set_clock_state(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			   uint32_t flags, uint8_t state);
+
+/**
+ * @brief Check if the clock is ON
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ * @param req_state Pointer to store whether the clock is managed and enabled
+ * @param curr_state Pointer to store whether the clock is ready for operation
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_clk_is_on(const struct device *dev, uint32_t dev_id, uint8_t clk_id, bool *req_state,
+			 bool *curr_state);
+
+/**
+ * @brief Check if the clock is OFF
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ * @param req_state Pointer to store whether the clock is managed and disabled
+ * @param curr_state Pointer to store whether the clock is NOT ready for operation
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_clk_is_off(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			  bool *req_state, bool *curr_state);
+
+/**
+ * @brief Check if the clock is being auto-managed
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ * @param req_state Pointer to store whether the clock is auto-managed
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_clk_is_auto(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			   bool *req_state);
+
+/**
+ * @brief Get the current frequency of a clock
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ * @param freq Pointer to store the current frequency in Hz
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_clk_get_freq(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			    uint64_t *freq);
+
+/**
+ * @brief Set a frequency for a clock
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ * @param min_freq Minimum allowable frequency in Hz
+ * @param target_freq Target clock frequency in Hz
+ * @param max_freq Maximum allowable frequency in Hz
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_clk_set_freq(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			    uint64_t min_freq, uint64_t target_freq, uint64_t max_freq);
+
+/**
+ * @brief Get a matching frequency for a clock
+ *
+ * Finds a frequency that matches the requested range for a clock.
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ * @param min_freq Minimum allowable frequency in Hz
+ * @param target_freq Target clock frequency in Hz
+ * @param max_freq Maximum allowable frequency in Hz
+ * @param match_freq Pointer to store the matched frequency in Hz
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_clk_get_match_freq(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+				  uint64_t min_freq, uint64_t target_freq, uint64_t max_freq,
+				  uint64_t *match_freq);
+
+/**
+ * @brief Set the parent clock for a clock
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ * @param parent_id Identifier of the parent clock to set
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_clk_set_parent(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			      uint8_t parent_id);
+
+/**
+ * @brief Get the parent clock for a clock
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ * @param parent_id Pointer to store the identifier of the parent clock
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_clk_get_parent(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+			      uint8_t *parent_id);
+
+/**
+ * @brief Get the number of parent clocks for a clock
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ * @param num_parents Pointer to store the number of parent clocks
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_clk_get_num_parents(const struct device *dev, uint32_t dev_id, uint8_t clk_id,
+				   uint8_t *num_parents);
+
+/**
+ * @brief Get control of a clock from TI SCI
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ * @param needs_ssc 'true' if Spread Spectrum clock is desired, else 'false'
+ * @param can_change_freq 'true' if frequency change is desired, else 'false'
+ * @param enable_input_term 'true' if input termination is desired, else 'false'
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_get_clock(const struct device *dev, uint32_t dev_id, uint8_t clk_id, bool needs_ssc,
+			 bool can_change_freq, bool enable_input_term);
+
+/**
+ * @brief Idle a clock that is under control of TI SCI
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_idle_clock(const struct device *dev, uint32_t dev_id, uint8_t clk_id);
+
+/**
+ * @brief Release a clock from control back to TI SCI
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clk_id Clock identifier for the device for this request
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_put_clock(const struct device *dev, uint32_t dev_id, uint8_t clk_id);
+
+/* Device Management Functions */
+
+/**
+ * @brief Set the state of a device
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param flags Flags to set for the device
+ * @param state State to move the device to:
+ *              - 0: Device is off
+ *              - 1: Device is on
+ *              - 2: Device is in retention
+ *              - 3: Device is in reset
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_set_device_state(const struct device *dev, uint32_t dev_id, uint32_t flags,
+			    uint8_t state);
+
+/**
+ * @brief Set the state of a device without waiting for a response
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param flags Flags to set for the device
+ * @param state State to move the device to:
+ *              - 0: Device is off
+ *              - 1: Device is on
+ *              - 2: Device is in retention
+ *              - 3: Device is in reset
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_set_device_state_no_wait(const struct device *dev, uint32_t dev_id, uint32_t flags,
+				    uint8_t state);
+
+/**
+ * @brief Get the state of a device
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param clcnt Pointer to store the Context Loss Count
+ * @param resets Pointer to store the reset count
+ * @param p_state Pointer to store the programmed state
+ * @param c_state Pointer to store the current state
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_get_device_state(const struct device *dev, uint32_t dev_id, uint32_t *clcnt,
+			    uint32_t *resets, uint8_t *p_state, uint8_t *c_state);
+
+/**
+ * @brief Request exclusive access to a device managed by TISCI
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_get_device(const struct device *dev, uint32_t dev_id);
+int ti_sci_cmd_get_device_exclusive(const struct device *dev, uint32_t dev_id);
+
+/**
+ * @brief Command to idle a device managed by TISCI
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_idle_device(const struct device *dev, uint32_t dev_id);
+int ti_sci_cmd_idle_device_exclusive(const struct device *dev, uint32_t dev_id);
+
+/**
+ * @brief Command to release a device managed by TISCI
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_put_device(const struct device *dev, uint32_t dev_id);
+
+/**
+ * @brief Check if a device ID is valid
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ *
+ * @return 0 if the device ID is valid, or an error code
+ */
+int ti_sci_cmd_dev_is_valid(const struct device *dev, uint32_t dev_id);
+
+/**
+ * @brief Get the context loss counter for a device
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param count Pointer to store the context loss counter
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_dev_get_clcnt(const struct device *dev, uint32_t dev_id, uint32_t *count);
+
+/**
+ * @brief Check if the device is requested to be idle
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param r_state Pointer to store the result (true if requested to be idle)
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_dev_is_idle(const struct device *dev, uint32_t dev_id, bool *r_state);
+
+/**
+ * @brief Check if the device is requested to be stopped
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param r_state Pointer to store the result (true if requested to be stopped)
+ * @param curr_state Pointer to store the result (true if currently stopped)
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_dev_is_stop(const struct device *dev, uint32_t dev_id, bool *r_state,
+			   bool *curr_state);
+
+/**
+ * @brief Check if the device is requested to be ON
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param r_state Pointer to store the result (true if requested to be ON)
+ * @param curr_state Pointer to store the result (true if currently ON and active)
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_dev_is_on(const struct device *dev, uint32_t dev_id, bool *r_state,
+			 bool *curr_state);
+
+/**
+ * @brief Check if the device is currently transitioning
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param curr_state Pointer to store the result (true if currently transitioning)
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_dev_is_trans(const struct device *dev, uint32_t dev_id, bool *curr_state);
+
+/**
+ * @brief Set resets for a device managed by TISCI
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param reset_state Device-specific reset bit field
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_set_device_resets(const struct device *dev, uint32_t dev_id, uint32_t reset_state);
+
+/**
+ * @brief Get reset state for a device managed by TISCI
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id Device identifier for this request
+ * @param reset_state Pointer to store the reset state
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_get_device_resets(const struct device *dev, uint32_t dev_id, uint32_t *reset_state);
+
+/* Resource Management Functions */
+
+/**
+ * @brief Get a range of resources assigned to a host
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id TISCI device ID
+ * @param subtype Resource assignment subtype being requested
+ * @param s_host Host processor ID to which the resources are allocated
+ * @param range_start Pointer to store the start index of the resource range
+ * @param range_num Pointer to store the number of resources in the range
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_get_resource_range(const struct device *dev, uint32_t dev_id, uint8_t subtype,
+			      uint8_t s_host, uint16_t *range_start, uint16_t *range_num);
+
+/**
+ * @brief Get a range of resources assigned to the host
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id TISCI device ID
+ * @param subtype Resource assignment subtype being requested
+ * @param range_start Pointer to store the start index of the resource range
+ * @param range_num Pointer to store the number of resources in the range
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_get_resource_range(const struct device *dev, uint32_t dev_id, uint8_t subtype,
+				  uint16_t *range_start, uint16_t *range_num);
+
+/**
+ * @brief Get a range of resources assigned to a specified host
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param dev_id TISCI device ID
+ * @param subtype Resource assignment subtype being requested
+ * @param s_host Host processor ID to which the resources are allocated
+ * @param range_start Pointer to store the start index of the resource range
+ * @param range_num Pointer to store the number of resources in the range
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_get_resource_range_from_shost(const struct device *dev, uint32_t dev_id,
+					     uint8_t subtype, uint8_t s_host, uint16_t *range_start,
+					     uint16_t *range_num);
+
+/* Processor Management Functions */
+
+/**
+ * @brief Command to request a physical processor control
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param proc_id Processor ID this request is for
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_proc_request(const struct device *dev, uint8_t proc_id);
+
+/**
+ * @brief Command to release a physical processor control
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param proc_id Processor ID this request is for
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_proc_release(const struct device *dev, uint8_t proc_id);
+
+/**
+ * @brief Command to handover a physical processor control to a host
+ *        in the processor's access control list
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param proc_id Processor ID this request is for
+ * @param host_id Host ID to get the control of the processor
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_proc_handover(const struct device *dev, uint8_t proc_id, uint8_t host_id);
+
+/**
+ * @brief Command to set the processor boot configuration flags
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param proc_id Processor ID this request is for
+ * @param bootvector Boot vector address
+ * @param config_flags_set Configuration flags to be set
+ * @param config_flags_clear Configuration flags to be cleared
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_set_proc_boot_cfg(const struct device *dev, uint8_t proc_id, uint64_t bootvector,
+				 uint32_t config_flags_set, uint32_t config_flags_clear);
+
+/**
+ * @brief Command to set the processor boot control flags
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param proc_id Processor ID this request is for
+ * @param control_flags_set Control flags to be set
+ * @param control_flags_clear Control flags to be cleared
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_set_proc_boot_ctrl(const struct device *dev, uint8_t proc_id,
+				  uint32_t control_flags_set, uint32_t control_flags_clear);
+
+/**
+ * @brief Command to authenticate and load the image, then set the processor configuration flags
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param image_addr Pointer to the memory address of the payload image and certificate
+ * @param image_size Pointer to the size of the image after authentication
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_proc_auth_boot_image(const struct device *dev, uint64_t *image_addr,
+				    uint32_t *image_size);
+
+/**
+ * @brief Command to get the processor boot status
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param proc_id Processor ID this request is for
+ * @param bv Pointer to store the boot vector
+ * @param cfg_flags Pointer to store the configuration flags
+ * @param ctrl_flags Pointer to store the control flags
+ * @param sts_flags Pointer to store the status flags
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_get_proc_boot_status(const struct device *dev, uint8_t proc_id, uint64_t *bv,
+				    uint32_t *cfg_flags, uint32_t *ctrl_flags, uint32_t *sts_flags);
+
+/**
+ * @brief Helper function to wait for a processor boot status without requesting or waiting for a
+ * response
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param proc_id Processor ID this request is for
+ * @param num_wait_iterations Total number of iterations to check before timeout
+ * @param num_match_iterations Number of consecutive matches required to confirm status
+ * @param delay_per_iteration_us Delay in microseconds between each status check
+ * @param delay_before_iterations_us Delay in microseconds before the first status check
+ * @param status_flags_1_set_all_wait Flags that must all be set to 1
+ * @param status_flags_1_set_any_wait Flags where at least one must be set to 1
+ * @param status_flags_1_clr_all_wait Flags that must all be cleared to 0
+ * @param status_flags_1_clr_any_wait Flags where at least one must be cleared to 0
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_proc_wait_boot_status_no_wait(const struct device *dev, uint8_t proc_id,
+					 uint8_t num_wait_iterations, uint8_t num_match_iterations,
+					 uint8_t delay_per_iteration_us,
+					 uint8_t delay_before_iterations_us,
+					 uint32_t status_flags_1_set_all_wait,
+					 uint32_t status_flags_1_set_any_wait,
+					 uint32_t status_flags_1_clr_all_wait,
+					 uint32_t status_flags_1_clr_any_wait);
+
+/**
+ * @brief Command to shutdown a core without requesting or waiting for a response
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param proc_id Processor ID this request is for
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_proc_shutdown_no_wait(const struct device *dev, uint8_t proc_id);
+
+/* Board Configuration Functions */
+
+/**
+ * @brief Set board configuration using a specified message type
+ *
+ * Sends a board configuration message to the TI SCI firmware with configuration
+ * data from a specified memory location.
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param msg_type TISCI message type for board configuration
+ * @param addr Physical address of board configuration data
+ * @param size Size of board configuration data in bytes
+ *
+ * @return 0 if successful, or an error code
+ */
+int cmd_set_board_config_using_msg(const struct device *dev, uint16_t msg_type, uint64_t addr,
+				   uint32_t size);
+
+/* Ring Configuration Function */
+
+/**
+ * @brief Configure a RA ring
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param valid_params Bitfield defining validity of ring configuration parameters
+ * @param nav_id Device ID of Navigator Subsystem from which the ring is allocated
+ * @param index Ring index
+ * @param addr_lo The ring base address low 32 bits
+ * @param addr_hi The ring base address high 32 bits
+ * @param count Number of ring elements
+ * @param mode The mode of the ring
+ * @param size The ring element size
+ * @param order_id Specifies the ring's bus order ID
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_ring_config(const struct device *dev, uint32_t valid_params, uint16_t nav_id,
+			   uint16_t index, uint32_t addr_lo, uint32_t addr_hi, uint32_t count,
+			   uint8_t mode, uint8_t size, uint8_t order_id);
+
+/* System Control Functions */
+
+/**
+ * @brief Request a system reset
+ *
+ * Commands the TI SCI firmware to perform a system reset.
+ *
+ * @param dev Pointer to the TI SCI device
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_sys_reset(const struct device *dev);
+
+/* Memory Management Functions */
+
+/**
+ * @brief Query the available MSMC memory range
+ *
+ * Queries the TI SCI firmware for the currently available MSMC (Multi-Standard
+ * Shared Memory Controller) memory range.
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param msmc_start Pointer to store the MSMC start address
+ * @param msmc_end Pointer to store the MSMC end address
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_query_msmc(const struct device *dev, uint64_t *msmc_start, uint64_t *msmc_end);
+
+/* Firewall Management Functions */
+
+/**
+ * @brief Configure a firewall region
+ *
+ * Sets up a firewall region with the specified configuration parameters
+ * including permissions, addresses, and control settings.
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param region Pointer to the firewall region configuration parameters
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_set_fwl_region(const struct device *dev, const struct ti_sci_msg_fwl_region *region);
+
+/* INCLUDE_ZEPHYR_DRIVERS_TISCI_H_ */
+
+/* Firewall Management Functions */
+/* ... previous firewall functions ... */
+
+/**
+ * @brief Get firewall region configuration
+ *
+ * Retrieves the configuration of a firewall region including permissions,
+ * addresses, and control settings.
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param region Pointer to store the firewall region configuration.
+ *              The fwl_id, region, and n_permission_regs fields must be
+ *              set before calling this function.
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_get_fwl_region(const struct device *dev, struct ti_sci_msg_fwl_region *region);
+
+/* INCLUDE_ZEPHYR_DRIVERS_TISCI_H_ */
+
+/* Firewall Management Functions */
+/* ... previous firewall functions ... */
+
+/**
+ * @brief Get firewall region configuration
+ *
+ * Retrieves the configuration of a firewall region including permissions,
+ * addresses, and control settings.
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param region Pointer to store the firewall region configuration.
+ *              The fwl_id, region, and n_permission_regs fields must be
+ *              set before calling this function.
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_get_fwl_region(const struct device *dev, struct ti_sci_msg_fwl_region *region);
+
+/* Firewall Management Functions */
+/* ... previous firewall functions ... */
+
+/**
+ * @brief Get firewall region configuration
+ *
+ * Retrieves the configuration of a firewall region including permissions,
+ * addresses, and control settings.
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param region Pointer to store the firewall region configuration.
+ *              The fwl_id, region, and n_permission_regs fields must be
+ *              set before calling this function.
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_get_fwl_region(const struct device *dev, struct ti_sci_msg_fwl_region *region);
+
+/* Firewall Management Functions */
+/* ... previous firewall functions ... */
+
+/**
+ * @brief Change firewall region owner
+ *
+ * Changes the ownership of a firewall region and retrieves updated
+ * ownership information.
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param owner Pointer to firewall owner configuration.
+ *             On input: contains fwl_id, region, and owner_index
+ *             On output: contains updated ownership information
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_change_fwl_owner(const struct device *dev, struct ti_sci_msg_fwl_owner *owner);
+
+/* UDMAP Management Functions */
+
+/**
+ * @brief Configure a UDMAP transmit channel
+ *
+ * Configures the non-real-time registers of a Navigator Subsystem UDMAP
+ * transmit channel.
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param params Pointer to the transmit channel configuration parameters
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_rm_udmap_tx_ch_cfg(const struct device *dev,
+				  const struct ti_sci_msg_rm_udmap_tx_ch_cfg *params);
+
+/**
+ * @brief Configure a UDMAP receive channel
+ *
+ * Configures the non-real-time registers of a Navigator Subsystem UDMAP
+ * receive channel.
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param params Pointer to the receive channel configuration parameters
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_rm_udmap_rx_ch_cfg(const struct device *dev,
+				  const struct ti_sci_msg_rm_udmap_rx_ch_cfg *params);
+
+/* PSI-L Management Functions */
+
+/**
+ * @brief Pair PSI-L source thread to destination thread
+ *
+ * Pairs a PSI-L source thread to a destination thread in the
+ * Navigator Subsystem.
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param nav_id Navigator Subsystem device ID
+ * @param src_thread Source thread ID
+ * @param dst_thread Destination thread ID
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_rm_psil_pair(const struct device *dev, uint32_t nav_id, uint32_t src_thread,
+			    uint32_t dst_thread);
+
+/**
+ * @brief Unpair PSI-L source thread from destination thread
+ *
+ * Unpairs a PSI-L source thread from a destination thread in the
+ * Navigator Subsystem.
+ *
+ * @param dev Pointer to the TI SCI device
+ * @param nav_id Navigator Subsystem device ID
+ * @param src_thread Source thread ID
+ * @param dst_thread Destination thread ID
+ *
+ * @return 0 if successful, or an error code
+ */
+int ti_sci_cmd_rm_psil_unpair(const struct device *dev, uint32_t nav_id, uint32_t src_thread,
+			      uint32_t dst_thread);
+
+#endif

--- a/include/zephyr/drivers/firmware/tisci/tisci_protocol.h
+++ b/include/zephyr/drivers/firmware/tisci/tisci_protocol.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025, Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __TISCI_PROTOCOL_ORIGINAL__
+#define __TISCI_PROTOCOL_ORIGINAL__
+#include <stdint.h>
+#include <zephyr/types.h> /* For u8, u16, etc. */
+#include <zephyr/types.h>
+
+#ifndef __packed
+#define __packed __attribute__((__packed__))
+#endif
+
+/**
+ * @struct ti_sci_msg_fwl_region_cfg
+ * @brief Request and Response for firewalls settings
+ *
+ * @param fwl_id:		Firewall ID in question
+ * @param region:		Region or channel number to set config info
+ *			This field is unused in case of a simple firewall  and must be initialized
+ *			to zero.  In case of a region based firewall, this field indicates the
+ *			region in question. (index starting from 0) In case of a channel based
+ *			firewall, this field indicates the channel in question (index starting
+ *			from 0)
+ * @param n_permission_regs:	Number of permission registers to set
+ * @param control:		Contents of the firewall CONTROL register to set
+ * @param permissions:	Contents of the firewall PERMISSION register to set
+ * @param start_address:	Contents of the firewall START_ADDRESS register to set
+ * @param end_address:	Contents of the firewall END_ADDRESS register to set
+ */
+struct ti_sci_msg_fwl_region {
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+	uint32_t control;
+	uint32_t permissions[3];
+	uint64_t start_address;
+	uint64_t end_address;
+} __packed;
+
+/**
+ * @brief Request and Response for firewall owner change
+ * @struct ti_sci_msg_fwl_owner
+ * @param fwl_id:		Firewall ID in question
+ * @param region:		Region or channel number to set config info
+ *			This field is unused in case of a simple firewall  and must be initialized
+ *			to zero.  In case of a region based firewall, this field indicates the
+ *			region in question. (index starting from 0) In case of a channel based
+ *			firewall, this field indicates the channel in question (index starting
+ *			from 0)
+ * @param n_permission_regs:	Number of permission registers <= 3
+ * @param control:		Control register value for this region
+ * @param owner_index:	New owner index to change to. Owner indexes are setup in DMSC firmware boot
+ *configuration data
+ * @param owner_privid:	New owner priv-id, used to lookup owner_index is not known, must be set to
+ *zero otherwise
+ * @param owner_permission_bits: New owner permission bits
+ */
+struct ti_sci_msg_fwl_owner {
+	uint16_t fwl_id;
+	uint16_t region;
+	uint8_t owner_index;
+	uint8_t owner_privid;
+	uint16_t owner_permission_bits;
+} __packed;
+
+/**
+ * Configures a Navigator Subsystem UDMAP transmit channel
+ *
+ * Configures a Navigator Subsystem UDMAP transmit channel registers.
+ * See ti_sci_msg_rm_udmap_tx_ch_cfg_req
+ */
+struct ti_sci_msg_rm_udmap_tx_ch_cfg {
+	uint32_t valid_params;
+#define TI_SCI_MSG_VALUE_RM_UDMAP_CH_TX_FILT_EINFO_VALID    BIT(9)
+#define TI_SCI_MSG_VALUE_RM_UDMAP_CH_TX_FILT_PSWORDS_VALID  BIT(10)
+#define TI_SCI_MSG_VALUE_RM_UDMAP_CH_TX_SUPR_TDPKT_VALID    BIT(11)
+#define TI_SCI_MSG_VALUE_RM_UDMAP_CH_TX_CREDIT_COUNT_VALID  BIT(12)
+#define TI_SCI_MSG_VALUE_RM_UDMAP_CH_TX_FDEPTH_VALID        BIT(13)
+#define TI_SCI_MSG_VALUE_RM_UDMAP_CH_TX_TDTYPE_VALID        BIT(15)
+#define TI_SCI_MSG_VALUE_RM_UDMAP_CH_EXTENDED_CH_TYPE_VALID BIT(16)
+	uint16_t nav_id;
+	uint16_t index;
+	uint8_t tx_pause_on_err;
+	uint8_t tx_filt_einfo;
+	uint8_t tx_filt_pswords;
+	uint8_t tx_atype;
+	uint8_t tx_chan_type;
+	uint8_t tx_supr_tdpkt;
+	uint16_t tx_fetch_size;
+	uint8_t tx_credit_count;
+	uint16_t txcq_qnum;
+	uint8_t tx_priority;
+	uint8_t tx_qos;
+	uint8_t tx_orderid;
+	uint16_t fdepth;
+	uint8_t tx_sched_priority;
+	uint8_t tx_burst_size;
+	uint8_t tx_tdtype;
+	uint8_t extended_ch_type;
+} __packed;
+
+/**
+ * Configures a Navigator Subsystem UDMAP receive channel
+ *
+ * Configures a Navigator Subsystem UDMAP receive channel registers.
+ * See ti_sci_msg_rm_udmap_rx_ch_cfg_req
+ */
+struct ti_sci_msg_rm_udmap_rx_ch_cfg {
+	uint32_t valid_params;
+#define TI_SCI_MSG_VALUE_RM_UDMAP_CH_RX_FLOWID_START_VALID BIT(9)
+#define TI_SCI_MSG_VALUE_RM_UDMAP_CH_RX_FLOWID_CNT_VALID   BIT(10)
+#define TI_SCI_MSG_VALUE_RM_UDMAP_CH_RX_IGNORE_SHORT_VALID BIT(11)
+#define TI_SCI_MSG_VALUE_RM_UDMAP_CH_RX_IGNORE_LONG_VALID  BIT(12)
+	uint16_t nav_id;
+	uint16_t index;
+	uint16_t rx_fetch_size;
+	uint16_t rxcq_qnum;
+	uint8_t rx_priority;
+	uint8_t rx_qos;
+	uint8_t rx_orderid;
+	uint8_t rx_sched_priority;
+	uint16_t flowid_start;
+	uint16_t flowid_cnt;
+	uint8_t rx_pause_on_err;
+	uint8_t rx_atype;
+	uint8_t rx_chan_type;
+	uint8_t rx_ignore_short;
+	uint8_t rx_ignore_long;
+	uint8_t rx_burst_size;
+};
+
+#endif /* __TISCI_PROTOCOL_ORIGINAL__*/


### PR DESCRIPTION
Added TISCI driver for supported devices using the binding ti,k2g-sci. This is used to communicate via the secury proxy channel for clock, resource and power domain management.
Refer: https://software-dl.ti.com/tisci/esd/latest/2_tisci_msgs/general/TISCI_header.html