### PR TITLE
drivers: firmware: Clock control TISCI driver support

### DIFF
--- a/drivers/clock_control/CMakeLists.txt
+++ b/drivers/clock_control/CMakeLists.txt
@@ -46,6 +46,7 @@ zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_NRF2_GLOBAL_HSFLL   clock_cont
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RTS5912_SCCON       clock_control_rts5912_sccon.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_NRF2_AUDIOPLL       clock_control_nrf2_audiopll.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_IT51XXX             clock_control_it51xxx.c)
+zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_TISCI               clock_control_tisci.c)
 
 if(CONFIG_CLOCK_CONTROL_NRF2)
   zephyr_library_sources(clock_control_nrf2_common.c)

--- a/drivers/clock_control/Kconfig
+++ b/drivers/clock_control/Kconfig
@@ -112,4 +112,6 @@ source "drivers/clock_control/Kconfig.wch_rcc"
 
 source "drivers/clock_control/Kconfig.it51xxx"
 
+source "drivers/clock_control/Kconfig.tisci"
+
 endif # CLOCK_CONTROL

--- a/drivers/clock_control/Kconfig.tisci
+++ b/drivers/clock_control/Kconfig.tisci
@@ -1,0 +1,9 @@
+# Copyright 2024 Texas Instruments Incorporated.
+# SPDX-License-Identifier: Apache-2.0
+
+config CLOCK_CONTROL_TISCI
+	bool "TI SCI Clock Control driver"
+	default y
+	depends on TISCI
+	help
+	  Driver for TISCI based clock control.

--- a/drivers/clock_control/clock_control_tisci.c
+++ b/drivers/clock_control/clock_control_tisci.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025, Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#define DT_DRV_COMPAT ti_k2g_sci_clk
+
+#include <stdint.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/firmware/tisci/ti_sci.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/tisci_clock_control.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(ti_k2g_sci_clk, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
+
+const struct device *dmsc = DEVICE_DT_GET(DT_NODELABEL(dmsc));
+
+static int tisci_get_rate(const struct device *dev, clock_control_subsys_t sys, uint32_t *rate)
+{
+	struct clock_config *req = (struct clock_config *)sys;
+	uint64_t temp_rate;
+	int ret = ti_sci_cmd_clk_get_freq(dmsc, req->dev_id, req->clk_id, &temp_rate);
+
+	if (ret) {
+		return ret;
+	}
+
+	*rate = (uint32_t)temp_rate;
+	return 0;
+}
+
+static int tisci_set_rate(const struct device *dev, void *sys, void *rate)
+{
+	struct clock_config *req = (struct clock_config *)sys;
+	uint64_t freq = *((uint64_t *)rate);
+	int ret = ti_sci_cmd_clk_set_freq(dmsc, req->dev_id, req->clk_id, freq, freq, freq);
+	return ret;
+}
+
+static inline enum clock_control_status tisci_get_status(const struct device *dev,
+							 clock_control_subsys_t sys)
+{
+	enum clock_control_status state = CLOCK_CONTROL_STATUS_UNKNOWN;
+	struct clock_config *req = (struct clock_config *)sys;
+	bool req_state = true;
+	bool curr_state = true;
+
+	ti_sci_cmd_clk_is_on(dmsc, req->clk_id, req->dev_id, &req_state, &curr_state);
+	if (curr_state) {
+		state = CLOCK_CONTROL_STATUS_ON;
+	}
+	if (req_state && !curr_state) {
+		state = CLOCK_CONTROL_STATUS_STARTING;
+	}
+	curr_state = true;
+	ti_sci_cmd_clk_is_off(dmsc, req->clk_id, req->dev_id, NULL, &curr_state);
+	if (curr_state) {
+		state = CLOCK_CONTROL_STATUS_OFF;
+	}
+	return state;
+}
+
+static DEVICE_API(clock_control, tisci_clock_driver_api) = {
+	.get_rate = tisci_get_rate, .set_rate = tisci_set_rate, .get_status = tisci_get_status};
+
+#define TI_K2G_SCI_CLK_INIT(_n)                                                                    \
+	DEVICE_DT_INST_DEFINE(_n, NULL, NULL, NULL, NULL, PRE_KERNEL_1,                            \
+			      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &tisci_clock_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(TI_K2G_SCI_CLK_INIT)

--- a/dts/bindings/clock/ti,k2g-sci-clk.yaml
+++ b/dts/bindings/clock/ti,k2g-sci-clk.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2021, Linaro Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+description: TI-SCI clock controller
+
+compatible: "ti,k2g-sci-clk"
+
+include:
+  - clock-controller.yaml
+  - base.yaml
+
+properties:
+  "#clock-cells":
+    type: int
+    required: true
+    description: >
+      Number of cells required to specify a clock provided by this controller.
+    const: 2
+
+clock-cells:
+  - devid
+  - clkid

--- a/include/zephyr/drivers/clock_control/tisci_clock_control.h
+++ b/include/zephyr/drivers/clock_control/tisci_clock_control.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_CLOCK_CONTROL_TISCI_CLOCK_CONTROL_H_
+#define ZEPHYR_DRIVERS_CLOCK_CONTROL_TISCI_CLOCK_CONTROL_H_
+
+/**
+ * @struct clock_config
+ * @brief Clock configuration structure
+ *
+ * This structure is used to define the configuration for a clock, including
+ * the device ID and clock ID.
+ *
+ * @param clock_config::dev_id
+ * Device ID associated with the clock.
+ *
+ * @param clock_config::clk_id
+ * Clock ID within the device.
+ */
+#include <stdint.h>
+struct clock_config {
+	uint32_t dev_id;
+	uint32_t clk_id;
+};
+
+#define TISCI_GET_CLOCK(_dev) DEVICE_DT_GET(DT_PHANDLE(DT_NODELABEL(_dev), clocks))
+#define TISCI_GET_CLOCK_DETAILS(_dev)                                                        \
+	{.dev_id = DT_CLOCKS_CELL(DT_NODELABEL(_dev), devid),                                \
+	 .clk_id = DT_CLOCKS_CELL(DT_NODELABEL(_dev), clkid)}
+#endif


### PR DESCRIPTION
Support added for clock control using TISCI added for devices using the binding ti,k2g-sci-clk.